### PR TITLE
Store -G/--group value into environment variable GROUP

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -28,6 +28,20 @@ then
     args="-name $schedd $args"
 fi
 
+# Check group and pull it into environment
+case "x$*" in
+*--group*)
+    group=`echo "$*" | sed -e 's/.*--group[=( )+]//' -e 's/ .*//'`
+    ;;
+*-G*)
+    group=`echo "$*" | sed -e 's/.*-G[( )+]//' -e 's/ .*//'`
+    ;;
+esac
+if [ x$group != x ]
+then
+    export GROUP=group
+fi
+
 export X509_USER_PROXY=`fake_ifdh getProxy`
 export BEARER_TOKEN_FILE=`fake_ifdh getToken`
 

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -32,9 +32,11 @@ fi
 case "x$*" in
 *--group*)
     group=`echo "$*" | sed -e 's/.*--group[=( )+]//' -e 's/ .*//'`
+    args=`echo "$*" | sed -e "s/--group[=( )+]$group//"`
     ;;
 *-G*)
     group=`echo "$*" | sed -e 's/.*-G[( )+]//' -e 's/ .*//'`
+    args=`echo "$*" | sed -e "s/-G[( )+]$group//"`
     ;;
 esac
 if [ x$group != x ]

--- a/bin/jobsub_q
+++ b/bin/jobsub_q
@@ -55,9 +55,11 @@ fi
 case "x$*" in
 *--group*)
     group=`echo "$*" | sed -e 's/.*--group[=( )+]//' -e 's/ .*//'`
+    args=`echo "$*" | sed -e "s/--group[=( )+]$group//"`
     ;;
 *-G*)
     group=`echo "$*" | sed -e 's/.*-G[( )+]//' -e 's/ .*//'`
+    args=`echo "$*" | sed -e "s/-G[( )+]$group//"`
     ;;
 esac
 if [ x$group != x ]

--- a/bin/jobsub_q
+++ b/bin/jobsub_q
@@ -41,13 +41,29 @@ fi
 
 schedd=""
 case "x$*" in
-*@*) schedd=`echo "$*" | sed -e 's/.*@//' -e 's/ .*//'`
-     args=`echo "$*" | sed -e 's/@[^ ]*//'`
-     ;;
+*@*)
+    schedd=`echo "$*" | sed -e 's/.*@//' -e 's/ .*//'`
+    args=`echo "$*" | sed -e 's/@[^ ]*//'`
+    ;;
 esac
 if [ x$schedd != x ]
 then
     args="-name $schedd $args"
 fi
+
+# Check group and pull it into environment
+case "x$*" in
+*--group*)
+    group=`echo "$*" | sed -e 's/.*--group[=( )+]//' -e 's/ .*//'`
+    ;;
+*-G*)
+    group=`echo "$*" | sed -e 's/.*-G[( )+]//' -e 's/ .*//'`
+    ;;
+esac
+if [ x$group != x ]
+then
+    export GROUP=group
+fi
+
 export BEARER_TOKEN_FILE=`fake_ifdh getToken`
 /usr/bin/condor_q -global $args | filter

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -29,6 +29,14 @@ def verify_executable_starts_with_file_colon(s):
         raise TypeError("executable must start with file://")
 
 
+class StoreGroupinEnvironment(argparse.Action):
+    """Action to store the given group in the GROUP environment variable"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        os.environ["GROUP"] = values
+        setattr(namespace, self.dest, values)
+
+
 def get_parser():
     """build the argument parser and return it"""
     parser = argparse.ArgumentParser()
@@ -96,7 +104,10 @@ def get_parser():
         help="generate and mail a summary report of completed/failed/removed jobs in a DAG",
     )
     parser.add_argument(
-        "-G", "--group", help="Group/Experiment/Subgroup for priorities and accounting"
+        "-G",
+        "--group",
+        help="Group/Experiment/Subgroup for priorities and accounting",
+        action=StoreGroupinEnvironment,
     )
     parser.add_argument(
         "-L", "--log_file", help="Log file to hold log output from job."


### PR DESCRIPTION
Added a callback `argparse.Action` to get_parser so that any inheriting module will automatically store the value of args.group into the environment variable GROUP.

For the shell scripts (jobsub_cmd, jobsub_q), pull the group flag/value out of the args, store it in GROUP, and modify args so that condor doesn't complain about the -G/--group flag getting passed.