### PR TITLE
Changes to spec file to make it work with a vanilla development env

### DIFF
--- a/spec/jobsub_lite.spec
+++ b/spec/jobsub_lite.spec
@@ -36,7 +36,7 @@ mkdir -p $RPM_BUILD_ROOT/opt/jobsub_lite/templates
 mkdir -p $RPM_BUILD_ROOT/etc/condor/config.d
 mkdir -p $RPM_BUILD_ROOT/etc/profile.d
 install -m 755 bin/* $RPM_BUILD_ROOT/opt/jobsub_lite/bin
-install -m 755 lib/* $RPM_BUILD_ROOT/opt/jobsub_lite/lib/
+install -m 755 lib/*.py $RPM_BUILD_ROOT/opt/jobsub_lite/lib/
 for d in templates/*
 do
     mkdir $RPM_BUILD_ROOT/opt/jobsub_lite/$d
@@ -91,22 +91,6 @@ install -m 755 spec/jobsub_lite.*h $RPM_BUILD_ROOT/etc/profile.d/
 /etc/condor/config.d/51-group_fermilab.configs
 /etc/profile.d/jobsub_lite.sh
 /etc/profile.d/jobsub_lite.csh
-/opt/jobsub_lite/lib/__pycache__/condor.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/creds.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/dagnabbit.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/get_parser.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/packages.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/poms_wrap.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/tarfiles.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/utils.cpython-36.pyc
-/opt/jobsub_lite/lib/__pycache__/condor.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/creds.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/dagnabbit.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/get_parser.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/packages.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/poms_wrap.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/tarfiles.cpython-36.opt-1.pyc
-/opt/jobsub_lite/lib/__pycache__/utils.cpython-36.opt-1.pyc
 %clean
 rm -rf $RPM_BUILD_ROOT
 

--- a/spec/jobsub_lite.spec
+++ b/spec/jobsub_lite.spec
@@ -34,6 +34,7 @@ mkdir -p $RPM_BUILD_ROOT/opt/jobsub_lite/bin
 mkdir -p $RPM_BUILD_ROOT/opt/jobsub_lite/lib
 mkdir -p $RPM_BUILD_ROOT/opt/jobsub_lite/templates
 mkdir -p $RPM_BUILD_ROOT/etc/condor/config.d
+mkdir -p $RPM_BUILD_ROOT/etc/profile.d
 install -m 755 bin/* $RPM_BUILD_ROOT/opt/jobsub_lite/bin
 install -m 755 lib/* $RPM_BUILD_ROOT/opt/jobsub_lite/lib/
 for d in templates/*

--- a/spec/jobsub_lite.spec
+++ b/spec/jobsub_lite.spec
@@ -47,6 +47,7 @@ install -m 755 spec/jobsub_lite.*h $RPM_BUILD_ROOT/etc/profile.d/
 
 %files
 %doc
+%exclude /opt/jobsub_lite/*/*.py?
 /opt/jobsub_lite/bin/condor_q
 /opt/jobsub_lite/bin/condor_release
 /opt/jobsub_lite/bin/condor_rm
@@ -91,8 +92,12 @@ install -m 755 spec/jobsub_lite.*h $RPM_BUILD_ROOT/etc/profile.d/
 /etc/condor/config.d/51-group_fermilab.configs
 /etc/profile.d/jobsub_lite.sh
 /etc/profile.d/jobsub_lite.csh
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
-
+* Wed Feb 23 2022 Shreyas Bhat <sbhat@fnal.gov> beta8
+- Added creation of /etc/profile.d in install section
+- Only install .py files from lib/ and exclude all auto-compiled .py{co} files from lib/ in files section
+- Remove __pycache__ files from files section


### PR DESCRIPTION
There were a few remnants in the spec file (__pycache__ files, byte-code files) that would only work if source code was run.  This change is to allow for building of the RPM in the case that tests were run on a different machine, and strips out the installation and inclusion of cached and byte-compiled files.