### PR TITLE
Update wrapper script templates to support roles

### DIFF
--- a/templates/dag/dagman_wrapper.sh
+++ b/templates/dag/dagman_wrapper.sh
@@ -3,6 +3,11 @@
 # condor wants to copy in the condor_dagman executable, but we
 # want it to run the local one, so we give it this one...
 
-export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
+{% if role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+{% else %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
+export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 exec /usr/bin/condor_dagman "$@"

--- a/templates/dag/dagman_wrapper.sh
+++ b/templates/dag/dagman_wrapper.sh
@@ -4,9 +4,9 @@
 # want it to run the local one, so we give it this one...
 
 {% if role and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
 {% else %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}
 export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 

--- a/templates/dataset_dag/dagman_wrapper.sh
+++ b/templates/dataset_dag/dagman_wrapper.sh
@@ -3,6 +3,11 @@
 # condor wants to copy in the condor_dagman executable, but we
 # want it to run the local one, so we give it this one...
 
-export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
+{% if role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+{% else %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
+export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 exec /usr/bin/condor_dagman "$@"

--- a/templates/dataset_dag/dagman_wrapper.sh
+++ b/templates/dataset_dag/dagman_wrapper.sh
@@ -4,9 +4,9 @@
 # want it to run the local one, so we give it this one...
 
 {% if role and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
 {% else %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}
 export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 

--- a/templates/dataset_dag/sambegin.sh
+++ b/templates/dataset_dag/sambegin.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -x
 
+{% if role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+{% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
 export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 setup_ifdh_env(){

--- a/templates/dataset_dag/samend.sh
+++ b/templates/dataset_dag/samend.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -x
 
+{% if role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+{% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
 export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 setup_ifdh_env(){

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -7,7 +7,11 @@
 
 umask 002
 
+{% if role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+{% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
 export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 set_jobsub_debug(){


### PR DESCRIPTION
The wrapper scripts were not correctly using the value of the --role flag to modify the default paths for the environment variables `BEARER_TOKEN_FILE` and `BEARER_TOKEN`.  This PR fixes that (#30 )