### PR TITLE
don't set BEARER_TOKEN in wrappers

### DIFF
--- a/templates/dag/dagman_wrapper.sh
+++ b/templates/dag/dagman_wrapper.sh
@@ -8,6 +8,5 @@ export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}
-export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 exec /usr/bin/condor_dagman "$@"

--- a/templates/dataset_dag/dagman_wrapper.sh
+++ b/templates/dataset_dag/dagman_wrapper.sh
@@ -8,6 +8,5 @@ export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}
-export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 exec /usr/bin/condor_dagman "$@"

--- a/templates/dataset_dag/sambegin.sh
+++ b/templates/dataset_dag/sambegin.sh
@@ -5,7 +5,6 @@ export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}
-export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 setup_ifdh_env(){
 #

--- a/templates/dataset_dag/samend.sh
+++ b/templates/dataset_dag/samend.sh
@@ -5,7 +5,6 @@ export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}
-export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 setup_ifdh_env(){
 #

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -12,7 +12,6 @@ export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}
-export BEARER_TOKEN=`cat "$BEARER_TOKEN_FILE"`
 
 set_jobsub_debug(){
     export PS4='$LINENO:'


### PR DESCRIPTION
Setting `BEARER_TOKEN` in the job environment is a potential security leak, exposing tokens in log files, etc. by the common practice to print the jobs environment for debugging. It's now set internally by ifdh v2_6_3 when a token file is discovered. Eventually gfal2 will support token discovery: https://its.cern.ch/jira/browse/DMC-1226.


Fixes #33