### PR TITLE
Issue 31

### DIFF
--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -96,7 +96,7 @@ def do_tarballs(args):
 
                 cid = "".join((args.group, "%2F", digest))
                 if args.verbose:
-	                _cid = re.sub("\%2F", "/", cid)
+                    _cid = re.sub("\%2F", "/", cid)
                     print(f"Using RCDS to publish tarball\ncid: {_cid}")
 
                 publisher = TarfilePublisherHandler(cid, proxy, token)

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -90,9 +90,9 @@ def do_tarballs(args):
                 proxy, token = get_creds()
 
                 if token:
-                    f = open(token,'r')
-                    token_string = f.read()
-                    f.close()
+                    with open(token, 'r') as f:
+                        token_string = f.read()
+                        token_string = token_string.strip() # Drop \n at end of token_string
 
                 if not args.group:
                     raise ValueError("No --group specified!")

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -184,8 +184,10 @@ class TarfilePublisherHandler(object):
         """
         url = self.pubapi_base_url_formatter.format(endpoint="update")
         if self.token:
+            print(f"Using bearer token located at {self.token} to authenticate to RCDS")
             return requests.get(url, headers=self.request_headers, verify=False)
         else:
+            print(f"Using X509 proxy located at {self.proxy} to authenticate to RCDS")
             return requests.get(url, cert=(self.proxy, self.proxy), verify=False)
 
     @pubapi_operation

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -95,6 +95,10 @@ def do_tarballs(args):
                     raise ValueError("No --group specified!")
 
                 cid = "".join((args.group, "%2F", digest))
+                if args.verbose:
+                    print("Using RCDS to publish tarball"
+                          f"cid: {cid}"
+                    )
 
                 publisher = TarfilePublisherHandler(cid, proxy, token)
                 location = publisher.cid_exists()

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -96,7 +96,9 @@ def do_tarballs(args):
 
                 cid = "".join((args.group, "%2F", digest))
                 if args.verbose:
-                    _cid = re.sub("\%2F", "/", cid)
+                    from urllib.parse import unquote as _unquote
+
+                    _cid = _unquote(cid)
                     print(f"Using RCDS to publish tarball\ncid: {_cid}")
 
                 publisher = TarfilePublisherHandler(cid, proxy, token)

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -96,9 +96,8 @@ def do_tarballs(args):
 
                 cid = "".join((args.group, "%2F", digest))
                 if args.verbose:
-                    print("Using RCDS to publish tarball"
-                          f"cid: {cid}"
-                    )
+	                _cid = re.sub("\%2F", "/", cid)
+                    print(f"Using RCDS to publish tarball\ncid: {_cid}")
 
                 publisher = TarfilePublisherHandler(cid, proxy, token)
                 location = publisher.cid_exists()

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -160,6 +160,10 @@ class TarfilePublisherHandler(object):
         )
         if token is not None:
             self.request_headers = self.__make_request_token_headers()
+            print(f"Using bearer token located at {self.token} to authenticate to RCDS")
+        else:
+            print(f"Using X509 proxy located at {self.proxy} to authenticate to RCDS")
+
 
     # Some sort of wrapper to wrap the above three
     def pubapi_operation(func):
@@ -184,10 +188,8 @@ class TarfilePublisherHandler(object):
         """
         url = self.pubapi_base_url_formatter.format(endpoint="update")
         if self.token:
-            print(f"Using bearer token located at {self.token} to authenticate to RCDS")
             return requests.get(url, headers=self.request_headers, verify=False)
         else:
-            print(f"Using X509 proxy located at {self.proxy} to authenticate to RCDS")
             return requests.get(url, cert=(self.proxy, self.proxy), verify=False)
 
     @pubapi_operation


### PR DESCRIPTION
Switch jobsub_lite to use tokens to authenticate to RCDS (or any other future webservice) for publishing tarballs.