### PR TITLE
reduce use of pkg_find

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -39,7 +39,6 @@ if PREFIX == '/usr':
 # this means we don't need fancy ups dependencies..
 #
 sys.path.append(os.path.join(PREFIX,"lib"))
-import packages
 
 #
 # import our local parts

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -36,21 +36,12 @@ import shutil
 #
 PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-#
-# find parts we need in package management
-# this means we don't need fancy ups dependencies..
-#
-sys.path.append(os.path.join(PREFIX,"lib"))
-from packages import pkg_find
-pkg_find("ifdhc","v2_5_15 -g jobsub_lite -q python36")
-pkg_find("ifdhc_config", "v2_5_15 -q tokens")
-pkg_find("jinja")
 import jinja2 as jinja
-import ifdh
 
 #
 # import our local parts
 #
+sys.path.append(os.path.join(PREFIX,"lib"))
 from get_parser import get_parser 
 from condor import  get_schedd, submit, submit_dag
 from dagnabbit import parse_dagnabbit

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -37,15 +37,8 @@ import shutil
 #
 PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-#
-# find parts we need in package management
-# this means we don't need fancy ups dependencies..
-#
-sys.path.append(os.path.join(PREFIX, "lib"))
-from packages import pkg_find
-
-pkg_find("jinja")
 import jinja2 as jinja
+sys.path.append(os.path.join(PREFIX, "lib"))
 
 #
 # import our local parts

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -19,7 +19,6 @@ import glob
 import re
 import htcondor
 import random
-import packages
 import subprocess
 
 random.seed()
@@ -122,7 +121,6 @@ def submit(f, vargs, schedd_name, cmd_args=[]):
     )
     cmd = "BEARER_TOKEN_FILE=%s %s" % (os.environ["BEARER_TOKEN_FILE"], cmd)
     cmd = "_condor_CREDD_HOST=%s %s" % (schedd_name, cmd)
-    packages.orig_env()
     print("Running: %s" % cmd)
 
     try:


### PR DESCRIPTION
Cleaning out references to pkg_find everywhere except (not yet used) poms_wrapper.py.
We get everything we need for normal operation from RPM dependencies now, so finding
things in ups/Spack isn't needed.
