### PR TITLE
All jobs default to running in fnal_wn SL7 singularity container.

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -57,10 +57,6 @@ from creds import get_creds
 from tarfiles import do_tarballs
 from utils import fixquote, set_extras_n_fix_units
 
-
-# DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest" . For Production
-DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:3.6"
-
 def get_basefiles(dlist):
     res = []
     for d in dlist:
@@ -163,28 +159,7 @@ def main():
     - launch
     """
     parser = get_parser()
-
-    submit_parser = parser.add_argument_group("jobsub_submit", "Arguments for jobsub_submit")
-    singularity_group = submit_parser.add_mutually_exclusive_group()
-    singularity_group.add_argument(
-        "--singularity-image",
-        default=DEFAULT_SINGULARITY_IMAGE,
-        help="Singularity image to run jobs in.  Default is "
-            f"{DEFAULT_SINGULARITY_IMAGE}"
-    )
-    singularity_group.add_argument(
-        "--no-singularity",
-        type=bool,
-        default=False
-        help="Don't request a singularity container.  If the site your job "
-            "lands on runs all jobs in singularity containers, your job will "
-            "also run in one.  If the site does not run all jobs in "
-            "singularity containers, your job will run outside a singularity "
-            "container."
-    )
-
     args = parser.parse_args()
-
 
     proxy, token = get_creds()
     if args.verbose:

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -57,6 +57,10 @@ from creds import get_creds
 from tarfiles import do_tarballs
 from utils import fixquote, set_extras_n_fix_units
 
+
+# DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest" . For Production
+DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:3.6"
+
 def get_basefiles(dlist):
     res = []
     for d in dlist:
@@ -159,6 +163,15 @@ def main():
     - launch
     """
     parser = get_parser()
+
+    submit_parser = parser.add_argument_group("jobsub_submit", "Arguments for jobsub_submit")
+    submit_parser.add_argument(
+        "--singularity-image",
+        default=DEFAULT_SINGULARITY_IMAGE,
+        help=f"Singularity image to run jobs in.  Default is {DEFAULT_SINGULARITY_IMAGE}"
+    )
+
+
     args = parser.parse_args()
 
 

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -165,12 +165,23 @@ def main():
     parser = get_parser()
 
     submit_parser = parser.add_argument_group("jobsub_submit", "Arguments for jobsub_submit")
-    submit_parser.add_argument(
+    singularity_group = submit_parser.add_mutually_exclusive_group()
+    singularity_group.add_argument(
         "--singularity-image",
         default=DEFAULT_SINGULARITY_IMAGE,
-        help=f"Singularity image to run jobs in.  Default is {DEFAULT_SINGULARITY_IMAGE}"
+        help="Singularity image to run jobs in.  Default is "
+            f"{DEFAULT_SINGULARITY_IMAGE}"
     )
-
+    singularity_group.add_argument(
+        "--no-singularity",
+        type=bool,
+        default=False
+        help="Don't request a singularity container.  If the site your job "
+            "lands on runs all jobs in singularity containers, your job will "
+            "also run in one.  If the site does not run all jobs in "
+            "singularity containers, your job will run outside a singularity "
+            "container."
+    )
 
     args = parser.parse_args()
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -246,7 +246,7 @@ def get_parser():
         "--singularity-image",
         default="/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
         help="Singularity image to run jobs in.  Default is "
-            f"{DEFAULT_SINGULARITY_IMAGE}"
+            "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
     )
     singularity_group.add_argument(
         "--no-singularity",

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -18,7 +18,7 @@ import sys
 import os
 
 # DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest" . For Production
-DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:3.6"
+DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:osg3.6"
 
 def verify_executable_starts_with_file_colon(s):
     """routine to give argparse to verify the executable parameter,

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -17,8 +17,6 @@ import argparse
 import sys
 import os
 
-# DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest" . For Production
-DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:osg3.6"
 
 def verify_executable_starts_with_file_colon(s):
     """routine to give argparse to verify the executable parameter,
@@ -246,7 +244,7 @@ def get_parser():
     singularity_group = parser.add_mutually_exclusive_group()
     singularity_group.add_argument(
         "--singularity-image",
-        default=DEFAULT_SINGULARITY_IMAGE,
+        default="/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
         help="Singularity image to run jobs in.  Default is "
             f"{DEFAULT_SINGULARITY_IMAGE}"
     )

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -17,6 +17,8 @@ import argparse
 import sys
 import os
 
+# DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest" . For Production
+DEFAULT_SINGULARITY_IMAGE = "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:3.6"
 
 def verify_executable_starts_with_file_colon(s):
     """routine to give argparse to verify the executable parameter,
@@ -241,7 +243,25 @@ def get_parser():
         help="executable for job to run",
     )
 
+    singularity_group = parser.add_mutually_exclusive_group()
+    singularity_group.add_argument(
+        "--singularity-image",
+        default=DEFAULT_SINGULARITY_IMAGE,
+        help="Singularity image to run jobs in.  Default is "
+            f"{DEFAULT_SINGULARITY_IMAGE}"
+    )
+    singularity_group.add_argument(
+        "--no-singularity",
+        action="store_true"
+        help="Don't request a singularity container.  If the site your job "
+            "lands on runs all jobs in singularity containers, your job will "
+            "also run in one.  If the site does not run all jobs in "
+            "singularity containers, your job will run outside a singularity "
+            "container."
+    )
+
     parser.add_argument(
         "exe_arguments", nargs=argparse.REMAINDER, help="arguments to executable"
     )
+
     return parser

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -252,7 +252,7 @@ def get_parser():
     )
     singularity_group.add_argument(
         "--no-singularity",
-        action="store_true"
+        action="store_true",
         help="Don't request a singularity container.  If the site your job "
             "lands on runs all jobs in singularity containers, your job will "
             "also run in one.  If the site does not run all jobs in "

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -43,6 +43,10 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
+{% if singularity_image is defined and no_singularity is false %}
++SingularityImage="{{singularity_image}}"
+{% endif %}
+
 {% if role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role}}
 {% else %}

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -43,7 +43,7 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
-{% if singularity_image is defined and no_singularity is false %}
+{% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"
 {% endif %}
 

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -44,6 +44,10 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
+{% if singularity_image is defined and no_singularity is false %}
++SingularityImage="{{singularity_image}}"
+{% endif %}
+
 {% if role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role}}
 {% else %}

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -44,7 +44,7 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
-{% if singularity_image is defined and no_singularity is false %}
+{% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"
 {% endif %}
 

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -52,7 +52,9 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = {%if overwrite_requirements %}{{overwrite_requirements}}{%else%}target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%endif%}{%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
+{% if singularity_image is defined and no_singularity is false %}
 +SingularityImage="{{singularity_image}}"
+{% endif %}
 
 #
 # this is supposed to get us output even if jobs are held(?)

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -52,7 +52,7 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = {%if overwrite_requirements %}{{overwrite_requirements}}{%else%}target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%endif%}{%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
-{% if singularity_image is defined and no_singularity is false %}
+{% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"
 {% endif %}
 

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -52,6 +52,8 @@ notify_user = {{email_to}}
 {{lines|join("\n+")}}
 requirements  = {%if overwrite_requirements %}{{overwrite_requirements}}{%else%}target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%endif%}{%if append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
 
++SingularityImage="{{singularity_image}}"
+
 #
 # this is supposed to get us output even if jobs are held(?)
 #

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -110,11 +110,13 @@ def all_test_args():
          '--mail_always',
          '--maxConcurrent', 'xxmaxConcurrentxx',
          '--memory', 'xxmemoryxx',
+         '--no-singularity',
          '--no_submit',
          '--OS', 'xxOSxx',
          '--overwrite_condor_requirements', 'xxoverwrite_condor_requirementsxx',
          '--resource-provides', 'xxresource-providesxx',
          '--role', 'xxrolexx',
+         '--singularity-image', 'xxsingularity-imagexx',
          '--site', 'xxsitexx',
          '--subgroup', 'xxsubgroupxx',
          '--tar_file_name', 'xxtar_file_namexx',
@@ -176,11 +178,38 @@ class TestGetParserUnit:
 
         allargs, flagargs, listargs, dest = find_all_arguments
 
+        # Args to exclude from checks below.  We need to do this due to,
+        # for example, mutually exclusive groups defined in the parser.
+        # Currently, the testing code here tries to parse all args, which
+        # works until you have a mutually exclusive group.  So the
+        # variable args_exclude_list should contain all the args in a 
+        # mutually exclusive group, except for one
+        # e.g. For the mutually exclusive group (--singularity-image,
+        # --no-singularity), we pick one and enter it into args_exclude_list
+        args_exclude_list = ['--no-singularity'] 
+
+        def filter_excluded(arg_list):
+            _stripped_args_exclude_list = [arg.strip('-') for arg in args_exclude_list]
+            def is_arg_excluded(arg):
+                return arg in args_exclude_list or arg in _stripped_args_exclude_list
+
+            return [arg for arg in arg_list if not is_arg_excluded(arg)]
+
+        allargs = filter_excluded(allargs)
+        flagargs = filter_excluded(flagargs) 
+        listargs = filter_excluded(listargs) 
+        all_test_args =  filter_excluded(all_test_args)
+
         print("trying command flags: ", all_test_args)
         
         parser = get_parser.get_parser()
         res = parser.parse_args(all_test_args)
         vres = vars(res)  
+        for arg in args_exclude_list:
+            remove_key = arg.strip('-').replace('-', '_')
+            vres.pop(remove_key, None)
+
+        
         print("vres is ", vres)
 
         #


### PR DESCRIPTION
This addresses #45.  It also changes the default behavior of jobs with regards to running in Singularity containers:

1. No flag:  job runs in `DEFAULT_SINGULARITY_IMAGE` (as specified in `get_parser.py`)
2. `--singularity-image`:  job runs in specified singularity container, if it exists.  If not, job will fail (this is similar to present condor behavior).
3. `--no-singularity`:  Do not specify any singularity image.  Job will run according to where it lands.  This might be in a singularity container, or it might not be.  