### PR TITLE
-G group /  better errors

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -106,8 +106,10 @@ def main():
     if args.group is not None:
         group = args.group
     else:
-        group = os.environ["GROUP"]
+        group = os.environ.get("GROUP",None)
 
+    if group == None:
+        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
 
     if args.test is not None:
         schedd_name = args.test

--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -108,7 +108,7 @@ def main():
     else:
         group = os.environ.get("GROUP",None)
 
-    if group == None:
+    if group is None:
         raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
 
     if args.test is not None:

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -75,6 +75,10 @@ def main():
     os.environ['X509_USER_PROXY'] = proxy
     os.environ['BEARER_TOKEN_FILE'] = token
 
+    if os.environ.get('GROUP',None) == None:
+        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
+
+
     schedd_add = get_schedd({})
     schedd_name = schedd_add.eval("Machine")
 

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -75,7 +75,7 @@ def main():
     os.environ['X509_USER_PROXY'] = proxy
     os.environ['BEARER_TOKEN_FILE'] = token
 
-    if os.environ.get('GROUP',None) == None:
+    if os.environ.get('GROUP',None) is None:
         raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
 
 

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -56,6 +56,9 @@ def main():
 
     arglist,passthru = parser.parse_known_args()
 
+    if os.environ.get('GROUP',None) == None:
+        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
+
     # make list of arguments to pass to condor command:
     # - the passthru arguments from above, except if we have
     #   any 234@schedd style arguments, pick out the schedd and

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -56,7 +56,7 @@ def main():
 
     arglist,passthru = parser.parse_known_args()
 
-    if os.environ.get('GROUP',None) == None:
+    if os.environ.get('GROUP',None) is None:
         raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
 
     # make list of arguments to pass to condor command:

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -68,7 +68,7 @@ def render_files(srcdir, values, dest, dlist=None):
     """
     print("trying to render files from %s\n" % srcdir)
 
-    if dlist == None:
+    if dlist is None:
         dlist = [ srcdir ]
     values["transfer_files"] = get_basefiles(dlist)
 
@@ -158,7 +158,7 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    if os.environ.get('GROUP',None) == None:
+    if os.environ.get('GROUP',None) is None:
         raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
 
 

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -158,6 +158,10 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    if os.environ.get('GROUP',None) == None:
+        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
+
+
     proxy, token = get_creds()
     if args.verbose:
         print("proxy is : %s" % proxy)

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -108,6 +108,7 @@ def get_parser():
         "--group",
         help="Group/Experiment/Subgroup for priorities and accounting",
         action=StoreGroupinEnvironment,
+        default=os.environ.get("GROUP",None)
     )
     parser.add_argument(
         "-L", "--log_file", help="Log file to hold log output from job."

--- a/lib/poms_wrap.py
+++ b/lib/poms_wrap.py
@@ -25,7 +25,7 @@ import poms_client
 
 def poms_wrap(args):
 
-    if os.environ.get("POMS_TASK_ID", None) == None:
+    if os.environ.get("POMS_TASK_ID", None) is None:
         # poms launch env not set, so skip...
         return
 


### PR DESCRIPTION
Currently jobsub_submit and friends blow up with a cryptic error if -G isn't set (defaulting to $GROUP in the
environment).   This patch checks early for this and error's out with a more specific error.