### PR TITLE
jobsub_fetchlog 

### DIFF
--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -112,18 +112,18 @@ def main():
     else:
         # build archive
         cmd = []
-        if args.archive_format == "zip":
-            cmd = ["/usr/bin/zip", "-jq", f"{str(j)}.zip"] + [
-                os.path.join(iwd, f) for f in files
-            ]
-            # -j: junk (don't record) directory names
-            # -q: quiet
-        elif args.archive_format == "tar":
+        if args.archive_format == "tar":
             cmd = ["/usr/bin/tar", "-C", iwd, "-czf", f"{str(j)}.tgz"] + files
             # -C: move into directory so paths are relative
             # -c: create
             # -z: gzip
             # -f: filename
+        elif args.archive_format == "zip":
+            cmd = ["/usr/bin/zip", "-jq", f"{str(j)}.zip"] + [
+                os.path.join(iwd, f) for f in files
+            ]
+            # -j: junk (don't record) directory names
+            # -q: quiet
         else:
             raise Exception(f'unknown archive format "{args.archive_format}"')
         if args.verbose:

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -40,12 +40,19 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 import creds
-from get_parser import StoreGroupinEnvironment
+from get_parser import get_base_parser
 from condor import Job
 
 
-def get_parser():
-    parser = argparse.ArgumentParser()
+def main():
+    """script mainline:
+    - parse args
+    - get credentials
+    - get job info
+    - condor_transfer_data
+    - make tarball
+    """
+    parser = get_base_parser()
     parser.add_argument("-J", "--jobid", help="job/submission ID", required=True)
     parser.add_argument(
         "--destdir",
@@ -58,32 +65,7 @@ def get_parser():
         help='format for downloaded archive: "tar" (default, compressed with gzip) or "zip"',
         default="tar",
     )
-    parser.add_argument(
-        "-G",
-        "--group",
-        help="Group/Experiment/Subgroup for priorities and accounting",
-        action=StoreGroupinEnvironment,
-        default=os.environ.get("GROUP", None),
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="dump internal state of program (useful for debugging)",
-    )
 
-    return parser
-
-
-def main():
-    """script mainline:
-    - parse args
-    - get credentials
-    - get job info
-    - condor_transfer_data
-    - make tarball
-    """
-    parser = get_parser()
     args = parser.parse_args()
 
     if args.verbose:

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -20,7 +20,6 @@
 import argparse
 import sys
 import os
-import os.path
 import subprocess
 import shutil
 
@@ -93,37 +92,45 @@ def main():
     try:
         os.stat(iwd)
     except FileNotFoundError:
-        os.mkdir(iwd, mode=0o750)
+        os.makedirs(iwd, mode=0o750)
 
     # get the output sandbox
     j.transfer_data()
+    files = os.listdir(iwd)
 
-    owd = iwd
-    # if the user wants output in a specific directory, copy files there
     if args.destdir is not None:
+        # If the user wants output in a specific directory, copy files there,
+        # don't build an archive. Old jobsub would get an archive from the
+        # server, upack it into the dest dir, then delete the archive.
         owd = args.destdir
-        shutil.copytree(iwd, owd)  # TODO python3.9+: dirs_exist_ok=True?
-
-    # build tarball
-    files = os.listdir(owd)
-    cmd = []
-    if args.archive_format == "zip":
-        cmd = ["/usr/bin/zip", "-jq", f"{str(j)}.zip"] + [owd + "/" + f for f in files]
-        # -j: junk (don't record) directory names
-        # -q: quiet
-    elif args.archive_format == "tar":
-        cmd = ["/usr/bin/tar", "-C", owd, "-czf", f"{str(j)}.tgz"] + files
-        # -C: move into directory so paths are relative
-        # -c: create
-        # -z: gzip
-        # -f: filename
+        try:
+            os.stat(owd)
+        except FileNotFoundError:
+            os.makedirs(owd, mode=0o750)
+        for f in files:
+            shutil.copy2(os.path.join(iwd, f), owd)  # copy2 tries to preserve metadata
     else:
-        raise Exception(f'unknown archive format "{args.archive_format}"')
-    if args.verbose:
-        print(f'running "{cmd}"')
-    p = subprocess.Popen(cmd)
-    if p.wait() != 0:
-        raise Exception(f"error creating archive")
+        # build archive
+        cmd = []
+        if args.archive_format == "zip":
+            cmd = ["/usr/bin/zip", "-jq", f"{str(j)}.zip"] + [
+                os.path.join(iwd, f) for f in files
+            ]
+            # -j: junk (don't record) directory names
+            # -q: quiet
+        elif args.archive_format == "tar":
+            cmd = ["/usr/bin/tar", "-C", iwd, "-czf", f"{str(j)}.tgz"] + files
+            # -C: move into directory so paths are relative
+            # -c: create
+            # -z: gzip
+            # -f: filename
+        else:
+            raise Exception(f'unknown archive format "{args.archive_format}"')
+        if args.verbose:
+            print(f'running "{cmd}"')
+        p = subprocess.Popen(cmd)
+        if p.wait() != 0:
+            raise Exception(f"error creating archive")
 
 
 if __name__ == "__main__":

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -1,0 +1,134 @@
+#!/usr/bin/python3 -I
+
+#
+# jobsub_fetchlog -- tool for downloading job output files from condor
+# COPYRIGHT 2022 FERMI NATIONAL ACCELERATOR LABORATORY
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+import os
+import os.path
+import subprocess
+
+import htcondor
+
+#
+# we are in prefix/bin/jobsub_fetchlog, so find our prefix
+#
+PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#
+# find parts we need in package management
+#
+sys.path.append(os.path.join(PREFIX, "lib"))
+
+#
+# import our local parts
+#
+import creds
+from get_parser import StoreGroupinEnvironment
+from condor import Job
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-J","--jobid", help="job/submission ID", required=True)
+    parser.add_argument("--destdir", "--unzipdir", help="Directory to automatically unarchive logs into")
+    parser.add_argument("--archive-format", help="format for downloaded archive: \"tar\" (default, compressed with gzip) or \"zip\"",default="tar")
+    parser.add_argument(
+        "-G",
+        "--group",
+        help="Group/Experiment/Subgroup for priorities and accounting",
+        action=StoreGroupinEnvironment,
+        default=os.environ.get("GROUP",None)
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="dump internal state of program (useful for debugging)",
+    )
+
+    return parser
+
+def main():
+    """script mainline:
+    - parse args
+    - get credentials
+    - get job info
+    - condor_transfer_data
+    - make tarball
+    """
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if args.verbose:
+        htcondor.set_subsystem("TOOL")
+        htcondor.param['TOOL_DEBUG'] = 'D_FULLDEBUG'
+        htcondor.enable_debug()
+
+    if os.environ.get('GROUP',None) is None:
+        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
+
+    proxy, token = creds.get_creds(vars(args))
+
+    if args.verbose:
+        print("proxy is : %s" % proxy)
+        print("token is : %s" % token)
+
+    # find where the condor_transfer_data will put the output
+    j = Job(args.jobid)
+    iwd = j.get_attribute("SUBMIT_Iwd")
+    if args.verbose:
+        print(f"job output to {iwd}")
+    # make sure it exists, create if not
+    try:
+        os.stat(iwd)
+    except FileNotFoundError:
+        os.mkdir(iwd, mode=0o750)
+
+    # get the output sandbox
+    j.transfer_data()
+
+    owd = iwd
+    # if the user wants output in a specific directory, rename it
+    if args.destdir is not None:
+        os.rename(iwd, args.destdir)
+        owd = args.destdir
+
+    # build tarball
+    files = os.listdir(owd)
+    cmd = []
+    if args.archive_format == "zip":
+       cmd = ["/usr/bin/zip","-jq",f"{str(j)}.zip"]+[owd+"/"+f for f in files]
+       # -j: junk (don't record) directory names
+       # -q: quiet
+    elif args.archive_format == "tar":
+       cmd = ["/usr/bin/tar","-C",owd,"-czf",f"{str(j)}.tgz"]+files
+       # -C: move into directory so paths are relative
+       # -c: create
+       # -z: gzip
+       # -f: filename
+    else:
+        raise Exception(f'unknown archive format "{args.archive_format}"')
+    if args.verbose:
+        print(f'running "{cmd}"')
+    p = subprocess.Popen(cmd)
+    if p.wait() != 0:
+        raise Exception(f'error creating archive')
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -22,6 +22,7 @@ import sys
 import os
 import os.path
 import subprocess
+import shutil
 
 import htcondor
 
@@ -42,17 +43,27 @@ import creds
 from get_parser import StoreGroupinEnvironment
 from condor import Job
 
+
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-J","--jobid", help="job/submission ID", required=True)
-    parser.add_argument("--destdir", "--unzipdir", help="Directory to automatically unarchive logs into")
-    parser.add_argument("--archive-format", help="format for downloaded archive: \"tar\" (default, compressed with gzip) or \"zip\"",default="tar")
+    parser.add_argument("-J", "--jobid", help="job/submission ID", required=True)
+    parser.add_argument(
+        "--destdir",
+        "--dest-dir",
+        "--unzipdir",
+        help="Directory to automatically unarchive logs into",
+    )
+    parser.add_argument(
+        "--archive-format",
+        help='format for downloaded archive: "tar" (default, compressed with gzip) or "zip"',
+        default="tar",
+    )
     parser.add_argument(
         "-G",
         "--group",
         help="Group/Experiment/Subgroup for priorities and accounting",
         action=StoreGroupinEnvironment,
-        default=os.environ.get("GROUP",None)
+        default=os.environ.get("GROUP", None),
     )
     parser.add_argument(
         "--verbose",
@@ -62,6 +73,7 @@ def get_parser():
     )
 
     return parser
+
 
 def main():
     """script mainline:
@@ -76,11 +88,13 @@ def main():
 
     if args.verbose:
         htcondor.set_subsystem("TOOL")
-        htcondor.param['TOOL_DEBUG'] = 'D_FULLDEBUG'
+        htcondor.param["TOOL_DEBUG"] = "D_FULLDEBUG"
         htcondor.enable_debug()
 
-    if os.environ.get('GROUP',None) is None:
-        raise AttributeError("%s needs -G group or $GROUP in the environment." %sys.argv[0])
+    if os.environ.get("GROUP", None) is None:
+        raise AttributeError(
+            "%s needs -G group or $GROUP in the environment." % sys.argv[0]
+        )
 
     proxy, token = creds.get_creds(vars(args))
 
@@ -103,31 +117,31 @@ def main():
     j.transfer_data()
 
     owd = iwd
-    # if the user wants output in a specific directory, rename it
+    # if the user wants output in a specific directory, copy files there
     if args.destdir is not None:
-        os.rename(iwd, args.destdir)
         owd = args.destdir
+        shutil.copytree(iwd, owd)  # TODO python3.9+: dirs_exist_ok=True?
 
     # build tarball
     files = os.listdir(owd)
     cmd = []
     if args.archive_format == "zip":
-       cmd = ["/usr/bin/zip","-jq",f"{str(j)}.zip"]+[owd+"/"+f for f in files]
-       # -j: junk (don't record) directory names
-       # -q: quiet
+        cmd = ["/usr/bin/zip", "-jq", f"{str(j)}.zip"] + [owd + "/" + f for f in files]
+        # -j: junk (don't record) directory names
+        # -q: quiet
     elif args.archive_format == "tar":
-       cmd = ["/usr/bin/tar","-C",owd,"-czf",f"{str(j)}.tgz"]+files
-       # -C: move into directory so paths are relative
-       # -c: create
-       # -z: gzip
-       # -f: filename
+        cmd = ["/usr/bin/tar", "-C", owd, "-czf", f"{str(j)}.tgz"] + files
+        # -C: move into directory so paths are relative
+        # -c: create
+        # -z: gzip
+        # -f: filename
     else:
         raise Exception(f'unknown archive format "{args.archive_format}"')
     if args.verbose:
         print(f'running "{cmd}"')
     p = subprocess.Popen(cmd)
     if p.wait() != 0:
-        raise Exception(f'error creating archive')
+        raise Exception(f"error creating archive")
 
 
 if __name__ == "__main__":

--- a/bin/jobsub_transfer_data
+++ b/bin/jobsub_transfer_data
@@ -1,1 +1,0 @@
-jobsub_cmd

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -271,17 +271,16 @@ class Job:
         if m is None:
             raise JobIdError(f'unable to parse job id "{job_id}"')
         try:
-            self.seq = int(m.group(1))
-            self.proc = int(m.group(2))
+            self.seq = int(m.group(1))  # seq is required
+            if m.group(2) is None:  # proc is optional
+                self.cluster = True
+                self.proc = 0
+            else:
+                self.cluster = False
+                self.proc = int(m.group(2))
+            self.schedd = m.group(3)  # schedd is required
         except TypeError as e:
-            raise JobIdError(
-                f"error converting job seq {m.group(1)} or proc {m.group(2)} to ints"
-            ) from e
-        self.cluster = False
-        if self.proc is None:
-            self.proc = 0
-            self.cluster = True
-        self.schedd = m.group(3)
+            raise JobIdError(f'error when parsing job id "{job_id}"') from e
 
     def __str__(self) -> str:
         if self.cluster:

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -176,12 +176,6 @@ def submit(
         if m:
             print(f"Use job id {m.group(1)}.0@{schedd_name} to retrieve output")
 
-        if "outdir" in vargs:
-            print(
-                f"Output will be in {vargs['outdir']} after running"
-                " jobsub_transfer_data."
-            )
-
         return True
     except OSError as e:
         print("Execution failed: ", e)
@@ -227,11 +221,6 @@ def submit_dag(
                 sys.stderr.write(
                     f"Error: Child was terminated by signal {-output.returncode}"
                 )
-            else:
-                if "outdir" in vargs:
-                    print(
-                        f"Output will be in {vargs['outdir']} after running jobsub_transfer_data."
-                    )
         except OSError as e:
             print("Execution failed: ", e)
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -44,9 +44,37 @@ class StoreGroupinEnvironment(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """build the argument parser and return it"""
+def get_base_parser() -> argparse.ArgumentParser:
+    """build the general jobsub command argument parser and return it"""
     parser = argparse.ArgumentParser()
+    group = parser.add_argument_group("general arguments")
+    group.add_argument(
+        "-G",
+        "--group",
+        help="Group/Experiment/Subgroup for priorities and accounting",
+        action=StoreGroupinEnvironment,
+        default=os.environ.get("GROUP", None),
+    )
+    group.add_argument(
+        "--role", help="VOMS Role for priorities and accounting", default="Analysis"
+    )
+    group.add_argument(
+        "--subgroup",
+        help=" Subgroup for priorities and accounting. See https://cdcvs.fnal.gov/redmine/projects/jobsub/wiki/ Jobsub_submit#Groups-Subgroups-Quotas-Priorities for more documentation on using --subgroup to set job quotas and priorities",
+    )
+    group.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="dump internal state of program (useful for debugging)",
+    )
+
+    return parser
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """build the jobsub_submit argument parser and return it"""
+    parser = get_base_parser()
     parser.add_argument(
         "-c",
         "--append-condor-requirements",
@@ -152,13 +180,6 @@ def get_parser() -> argparse.ArgumentParser:
         " jobs in a DAG",
     )
     parser.add_argument(
-        "-G",
-        "--group",
-        help="Group/Experiment/Subgroup for priorities and accounting",
-        action=StoreGroupinEnvironment,
-        default=os.environ.get("GROUP", None),
-    )
-    parser.add_argument(
         "-L", "--log-file", "--log_file", help="Log file to hold log output from job."
     )
     parser.add_argument(
@@ -258,18 +279,7 @@ def get_parser() -> argparse.ArgumentParser:
         ' +DESIRED_CVMFS="OSG" to the job classad attributes and'
         " '&&(CVMFS==\"OSG\")' to the job requirements",
     )
-    parser.add_argument(
-        "--role", help="VOMS Role for priorities and accounting", default="Analysis"
-    )
     parser.add_argument("--site", help="submit jobs to these (comma-separated) sites")
-    parser.add_argument(
-        "--subgroup",
-        help=" Subgroup for priorities and accounting. See"
-        " https://cdcvs.fnal.gov/redmine/projects/jobsub/wiki/"
-        "Jobsub_submit#Groups-Subgroups-Quotas-Priorities for more"
-        "documentation on using --subgroup to set job quotas and"
-        "priorities",
-    )
     parser.add_argument(
         "--tar_file_name",
         "--tar-file-name",
@@ -311,12 +321,6 @@ def get_parser() -> argparse.ArgumentParser:
         const="pnfs",
         help="use cvmfs for dropbox (default is pnfs)",
         default=None,
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="dump internal state of program (useful for debugging)",
     )
     parser.add_argument(
         "--devserver",

--- a/spec/jobsub_lite.spec
+++ b/spec/jobsub_lite.spec
@@ -59,11 +59,11 @@ install -m 755 spec/jobsub_lite.*h $RPM_BUILD_ROOT/etc/profile.d/
 /opt/jobsub_lite/bin/decode_token.sh
 /opt/jobsub_lite/bin/jobsub_cmd
 /opt/jobsub_lite/bin/jobsub_hold
+/opt/jobsub_lite/bin/jobsub_fetchlog
 /opt/jobsub_lite/bin/jobsub_q
 /opt/jobsub_lite/bin/jobsub_release
 /opt/jobsub_lite/bin/jobsub_rm
 /opt/jobsub_lite/bin/jobsub_submit
-/opt/jobsub_lite/bin/jobsub_transfer_data
 /opt/jobsub_lite/bin/jobsub_wait
 /opt/jobsub_lite/lib/condor.py
 /opt/jobsub_lite/lib/creds.py
@@ -98,6 +98,9 @@ install -m 755 spec/jobsub_lite.*h $RPM_BUILD_ROOT/etc/profile.d/
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Thu Sep 01 2022 Kevin Retzke <kretzke@fnal.gov> beta13
+- Removed bin/jobsub_transfer_data, add bin/jobsub_fetchlog in files list
+
 * Thu Jul 21 2022 Shreyas Bhat <sbhat@fnal.gov> beta12
 - Removed bin/fake_ifdh from files list
 

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -145,3 +145,36 @@ class TestCondorUnit:
             get_dag_file, TestUnit.test_vargs, TestUnit.test_schedd, cmd_args=[]
         )
         assert res
+
+
+class TestJob:
+    def test_job(self):
+        jid = "123.456@foo.example.com"
+        j = condor.Job(jid)
+        assert j.id == jid
+        assert j.seq == 123
+        assert j.proc == 456
+        assert j.schedd == "foo.example.com"
+        assert not j.cluster
+        assert str(j) == jid
+        assert j._constraint() == "ClusterId==123 && ProcId==456"
+
+    def test_cluster(self):
+        jid = "123@foo.example.com"
+        j = condor.Job(jid)
+        assert j.id == jid
+        assert j.seq == 123
+        assert j.proc == 0
+        assert j.schedd == "foo.example.com"
+        assert j.cluster
+        assert str(j) == jid
+        assert j._constraint() == "ClusterId==123"
+
+    def test_bad_jobs(self):
+        for jid in ["foo", "foo@example.com" "foo.bar@example.com"]:
+            try:
+                j = condor.Job(jid)
+            except condor.JobIdError:
+                pass
+            else:
+                raise Exception(f"job id {jid} should have raised JobIdError")

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -148,6 +148,7 @@ class TestCondorUnit:
 
 
 class TestJob:
+    @pytest.mark.unit
     def test_job(self):
         jid = "123.456@foo.example.com"
         j = condor.Job(jid)
@@ -159,6 +160,7 @@ class TestJob:
         assert str(j) == jid
         assert j._constraint() == "ClusterId==123 && ProcId==456"
 
+    @pytest.mark.unit
     def test_cluster(self):
         jid = "123@foo.example.com"
         j = condor.Job(jid)
@@ -170,6 +172,7 @@ class TestJob:
         assert str(j) == jid
         assert j._constraint() == "ClusterId==123"
 
+    @pytest.mark.unit
     def test_bad_jobs(self):
         for jid in ["foo", "foo@example.com" "foo.bar@example.com"]:
             try:


### PR DESCRIPTION
This adds a new `jobsub_fetchlog` binary that queries schedd to determine what local path the sandbox files will be downloaded to, then downloads the files and puts them into an archive, optionally copying them to another directory as well. Uses `htcondor` python bindings.

This adds a `Job` class in `lib/condor` that parses job IDs and handles the condor interactions.  I haven't looked at using it in other places where job ids are parsed (like the `jobsub_cmd` wrapper).

Fixes #10 

