### PR TITLE
Code changes to enable pre-commit.ci github action.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+ci:
+  autofix_prs: false
+  autoupdate_branch: 'pre-commit.ci-autoupdate'
+  autoupdate_schedule: 'quarterly'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/shreyb/jobsub_lite/master.svg)](https://results.pre-commit.ci/latest/github/shreyb/jobsub_lite/master)
+
 #  `jobsub_lite` Overview
 
 jobsub_lite is a wrapper for Condor job submission, intended

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is also a simplified dagnabbit parser (again for past jobsub DAG tools com
 
 ## Credentials
 
-This version of jobsub is expected to deal with SciTokens credentials; and will use the new ifdhc getToken call to fetch them, which in turn will call the htgettoken utility.  Current thinking is that production accounts will have special production tokens pushed to them, and the utility will not have to get those tokens.
+This version of jobsub is expected to deal with SciTokens credentials; and will use the new ifdhc getToken call to fetch them, which in turn will call the htgettoken utility. Production accounts will have special production tokens pushed to them via the Managed Tokens Service, and this utility will not have to get those tokens.
 
 ## Command line parsing
 


### PR DESCRIPTION
This PR adds a minimal config to have the pre-commit.ci github action run our pre-commit checks.  The one thing I'm not happy about is that the pre-commit hooks autoupdate can't be turned off entirely - so I scheduled it to run quarterly, and open any PRs regarding those into a separate branch.  After we move off python3.6, this shouldn't be an issue anymore.