### PR TITLE
remove EXPERIMENT variable in favor of GROUP

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -39,9 +39,8 @@ def getTmp() -> str:
 
 def getExp() -> Union[str, None]:
     """return current experiment name"""
-    for ev in ["GROUP", "EXPERIMENT", "SAM_EXPERIMENT"]:
-        if os.environ.get(ev, None):
-            return os.environ.get(ev)
+    if os.environ.get("GROUP", None):
+        return os.environ.get("GROUP")
     # otherwise guess primary group...
     exp = None
     with os.popen("id -gn", "r") as f:

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -36,13 +36,6 @@ def test_getExp_GROUP():
     assert res == "samdev"
 
 
-def test_getExp_GROUP():
-    os.environ["GROUP"] = ""
-    os.environ["EXPERIMENT"] = "samdev"
-    res = fake_ifdh.getExp()
-    assert res == "samdev"
-
-
 def test_getRole():
     res = fake_ifdh.getRole()
     assert res == fake_ifdh.DEFAULT_ROLE


### PR DESCRIPTION
We agreed to use the variable GROUP exclusively in jobsub code to define the VO. I removed references to the other variables with the same meaning.