### PR TITLE
Make sure we set _condor_CREDD_HOST if we know it

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -74,6 +74,8 @@ def main() -> None:
         if m:
             # looks like a jobsub id 12.34@schedd.name
             schedd = m.group(2)
+            if not os.getenv("_condor_CREDD_HOST", None):
+                os.environ["_condor_CREDD_HOST"] = schedd
             i = m.group(1)
             if not i:
                 continue


### PR DESCRIPTION
This is a quick fix for Issue #98.  We simply set the environment variable `_condor_CREDD_HOST` to whatever schedd is passed in on the command line, if it is indeed passed in.  Verified that this fixes the issue as seen in #98 with `jobsub_transfer_data`.

closes #98 