### PR TITLE
Added fixture setup_ups to set up UPS in test environment

### DIFF
--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -20,7 +20,7 @@ from test_unit import TestUnit
 @pytest.fixture
 def needs_credentials():
     os.environ["GROUP"] = TestUnit.test_group
-    return creds.get_creds()
+    return creds.get_creds({"role": "Analysis"})
 
 
 @pytest.fixture

--- a/tests/test_packages_unit.py
+++ b/tests/test_packages_unit.py
@@ -1,4 +1,6 @@
 import os
+import shlex
+import subprocess
 import sys
 import pytest
 
@@ -16,6 +18,26 @@ sys.path.append("../lib")
 import packages
 
 
+@pytest.fixture
+def setup_ups(monkeypatch):
+    """A fixture to set up UPS for our tests, in case it is not already set up in the test environment.
+    Adapted from https://stackoverflow.com/a/3505826
+    """
+    keys = []
+    command = shlex.split(
+        "env -i bash -c 'source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh && env'"
+    )
+    source_proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    for line in source_proc.stdout:
+        (env_key, _, env_value) = line.decode().partition("=")
+        keys.append(env_key)
+        monkeypatch.setenv(env_key, env_value)
+    source_proc.communicate()
+    yield
+    for key in keys:
+        monkeypatch.delenv(key)
+
+
 class TestPackagesUnit:
     """
     Use with pytest... unit tests for ../lib/*.py
@@ -24,7 +46,7 @@ class TestPackagesUnit:
     # lib/packages.py routines
 
     @pytest.mark.unit
-    def test_pkg_find_1(self):
+    def test_pkg_find_1(self, setup_ups):
         """make sure we can find the poms_client ups package"""
         sp1 = sys.path.copy()
         packages.pkg_find("poms_client", "-g poms41")
@@ -35,7 +57,7 @@ class TestPackagesUnit:
         __import__("poms_client")
 
     @pytest.mark.unit
-    def test_pkg_orig_env_1(self):
+    def test_pkg_orig_env_1(self, setup_ups):
         """make sure orig_env puts the environment back"""
         packages.pkg_find("poms_client", "-g poms41")
         env1 = os.environ.copy()

--- a/tests/test_packages_unit.py
+++ b/tests/test_packages_unit.py
@@ -41,7 +41,8 @@ def setup_ups(monkeypatch):
                 "Could not set up UPS in environment.  Any unit test using this fixture might fail."
             )
     except Exception as e:
-        # Let the test run, with the possiblity that we might fail.  The tester may have Spack, or the applicable package installed directly via RPM
+        # Let the test run, with the possiblity that we might fail.
+        # The tester may have Spack, or the applicable package installed directly via RPM
         print(e)
     else:
         for env_key, env_value in env_to_add.items():


### PR DESCRIPTION
This PR just adds a fixture to the `test_packages_unit` tests that sets up UPS, in case it's not already set up in the user's environment.  In a standard terminal/shell, a developer can just set up UPS/Spack, and then run the pytest command manually; but in an IDE like VSCode, PyCharm, etc., the environment for the native IDE testing functionality is often separate from the built-in terminal, and so simply sourcing a script won't work.  This change should ensure that no matter where a developer is running the tests from, as long as UPS is available, the unit tests should behave as expected.