### PR TITLE
Made value for "resource_provides" a list, like get_parser.py would return

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -19,7 +19,7 @@ class TestUnit:
         "group": test_group,
         "N": 1,
         "maxConcurrent": None,
-        "resource_provides": "usage_model=OPPORTUNISTIC,DEDICATED,OFFSITE",
+        "resource_provides": ["usage_model=OPPORTUNISTIC,DEDICATED,OFFSITE"],
     }
     test_extra_template_args = {
         "role": "Analysis",


### PR DESCRIPTION
Lisa's PR (#101 ) revealed that our tests were treating "resource_provides" like a string, rather than a list, which is what get_parser.py defines for the --resource-provides flag (see https://github.com/marcmengel/jobsub_lite/blob/master/lib/get_parser.py#L254).  That made this test (https://github.com/marcmengel/jobsub_lite/blob/master/tests/test_utils_unit.py#L61) fail.  Fixed that here.