### PR TITLE
Bugfix for htgettoken URL not showing up

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -116,11 +116,10 @@ def getToken(role: str = DEFAULT_ROLE, debug: int = 0) -> str:
             cmd = f"{cmd} -r {role.lower()}"  # Token-world wants all-lower
 
         if debug > 0:
-            # send htgettoken output to stderr because invokers read stdout
             sys.stderr.write(f"Running: {cmd}")
-            cmd += " >&2"
-        else:
-            cmd += " >/dev/null 2>&1"
+
+        # send htgettoken output to stderr because invokers read stdout
+        cmd += " 2>&1"
 
         res = os.system(cmd)
         if res != 0:

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -118,7 +118,7 @@ def getToken(role: str = DEFAULT_ROLE, debug: int = 0) -> str:
         if debug > 0:
             sys.stderr.write(f"Running: {cmd}")
 
-        # send htgettoken output to stderr because invokers read stdout
+        # send htgettoken stderr to stdout because invokers read stdout
         cmd += " 2>&1"
 
         res = os.system(cmd)

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -118,9 +118,6 @@ def getToken(role: str = DEFAULT_ROLE, debug: int = 0) -> str:
         if debug > 0:
             sys.stderr.write(f"Running: {cmd}")
 
-        # send htgettoken stderr to stdout because invokers read stdout
-        cmd += " 2>&1"
-
         res = os.system(cmd)
         if res != 0:
             raise PermissionError(f"Failed attempting '{cmd}'")


### PR DESCRIPTION
This just makes sure to print the stdout from htgettoken, since under normal conditions, it's not that much output.

More importantly, the user needs to see the authentication URL if they're getting the token for the first time