### PR TITLE
Host cleanup part 1

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -39,7 +39,7 @@ from condor import get_schedd, submit
 from creds import get_creds
 
 # pylint: disable-next=no-member
-COLLECTOR_HOST = htcondor.param.get("COLLECTOR_HOST", "gpcollector03.fnal.gov")
+COLLECTOR_HOST = htcondor.param.get("COLLECTOR_HOST", None)
 
 
 class StoreGroupinEnvironment(argparse.Action):

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -30,7 +30,7 @@ import packages
 random.seed()
 
 # pylint: disable-next=no-member
-COLLECTOR_HOST = htcondor.param.get("COLLECTOR_HOST", "gpcollector03.fnal.gov")
+COLLECTOR_HOST = htcondor.param.get("COLLECTOR_HOST", None)
 
 
 # pylint: disable-next=no-member

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -31,7 +31,7 @@ from typing import Union, Optional, List
 
 import htcondor  # type: ignore
 
-VAULT_OPTS = htcondor.config.get("SEC_CREDENTIAL_GETTOKEN_OPTS", "")
+VAULT_OPTS = htcondor.param.get("SEC_CREDENTIAL_GETTOKEN_OPTS", "")
 DEFAULT_ROLE = "Analysis"
 
 

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 """ifdh replacemnents to remove dependency"""
 
+import argparse
 import json
 import os
 import re
@@ -26,10 +27,11 @@ import shlex
 import subprocess
 import sys
 import time
-import argparse
 from typing import Union, Optional, List
 
-VAULT_HOST = "fermicloud543.fnal.gov"
+import htcondor  # type: ignore
+
+VAULT_OPTS = htcondor.config.get("SEC_CREDENTIAL_GETTOKEN_OPTS", "")
 DEFAULT_ROLE = "Analysis"
 
 
@@ -110,7 +112,7 @@ def getToken(role: str = DEFAULT_ROLE, debug: int = 0) -> str:
         os.environ["BEARER_TOKEN_FILE"] = tokenfile
 
     if not checkToken(tokenfile):
-        cmd = f"htgettoken -a {VAULT_HOST} -i {issuer}"
+        cmd = f"htgettoken {VAULT_OPTS} -i {issuer}"
 
         if role != DEFAULT_ROLE:
             cmd = f"{cmd} -r {role.lower()}"  # Token-world wants all-lower

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -199,9 +199,7 @@ class TarfilePublisherHandler:
         token (str): Location of JWT/Sci-token to authenticate to RCDS
     """
 
-    dropbox_server_string = os.getenv(
-        "JOBSUB_DROPBOX_SERVER_LIST", "rcds01.fnal.gov rcds02.fnal.gov"
-    )
+    dropbox_server_string = os.getenv("JOBSUB_DROPBOX_SERVER_LIST", "")
     check_tarball_present_re = re.compile(
         "^PRESENT:(.+)$"
     )  # RCDS returns this if a tarball represented by cid is present

--- a/spec/jobsub_lite.csh
+++ b/spec/jobsub_lite.csh
@@ -1,1 +1,2 @@
 set path = ( /opt/jobsub_lite/bin $path )
+setenv JOBSUB_DROPBOX_SERVER_LIST="rcds01.fnal.gov rcds02.fnal.gov"

--- a/spec/jobsub_lite.csh
+++ b/spec/jobsub_lite.csh
@@ -1,2 +1,2 @@
 set path = ( /opt/jobsub_lite/bin $path )
-setenv JOBSUB_DROPBOX_SERVER_LIST="rcds01.fnal.gov rcds02.fnal.gov"
+setenv JOBSUB_DROPBOX_SERVER_LIST "rcds01.fnal.gov rcds02.fnal.gov"

--- a/spec/jobsub_lite.sh
+++ b/spec/jobsub_lite.sh
@@ -1,1 +1,2 @@
 PATH=/opt/jobsub_lite/bin:$PATH
+export JOBSUB_DROPBOX_SERVER_LIST="rcds01.fnal.gov rcds02.fnal.gov"

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -35,7 +35,7 @@ arguments          =
 output             = lookaround.xx.$(Cluster).$(Process).out
 error              = lookaround.xx.$(Cluster).$(Process).err
 log                = lookaround.xx.$(Cluster).$(Process).log
-environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP=;BEARER_TOKEN_FILE=.condor_creds/{group}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={user};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@jobsubdevgpvm01.fnal.gov;EXPERIMENT={group};SAM_EXPERIMENT=samdev
+environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP=;BEARER_TOKEN_FILE=.condor_creds/{group}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={user};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@schedd.example.com;EXPERIMENT={group};SAM_EXPERIMENT=samdev
 rank               = Mips / 2 + Memory
 job_lease_duration = 3600
 notification       = Never
@@ -56,9 +56,9 @@ request_disk = 102400.0KB
 notify_user = {user}@fnal.gov
 +AccountingGroup = "group_{group}.{user}"
 +Jobsub_Group="{group}"
-+JobsubJobId="$(CLUSTER).$(PROCESS)@jobsubdevgpvm01.fnal.gov"
++JobsubJobId="$(CLUSTER).$(PROCESS)@schedd.example.com"
 +Drain = False
-+GeneratedBy =" jobsubdevgpvm01.fnal.gov"
++GeneratedBy = "schedd.example.com"
 
 +DESIRED_usage_model="OPPORTUNISTIC,DEDICATED"
 

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -72,10 +72,21 @@ def dune(job_envs):
     os.environ["SAM_STATION"] = "dune"
 
 
+def get_collector():
+    """obfuscated way to find collector for dune pool"""
+    cp = "collector"[:4]
+    hn = os.environ["HOSTNAME"]
+    exp = os.environ["GROUP"]
+    dom = hn[hn.find(".") :]
+    n = dom.find(".", 1) - 3
+    col = f"{exp}gp{cp}0{n}{dom}"
+    return col
+
+
 @pytest.fixture
 def dune_gp(dune):
     """fixture to run launches for dune global pool"""
-    os.environ["_condor_COLLECTOR_HOST"] = "dunegpcoll02.fnal.gov"
+    os.environ["_condor_COLLECTOR_HOST"] = get_collector()
 
 
 joblist = []
@@ -252,7 +263,8 @@ def test_dune_gp_fife_launch(dune_gp):
 def group_for_job(jid):
     if jid.find("dune") > 0:
         group = "dune"
-        os.environ["_condor_COLLECTOR_HOST"] = "dunegpcoll02.fnal.gov"
+        os.environ["GROUP"] = group
+        os.environ["_condor_COLLECTOR_HOST"] = get_collector()
     else:
         group = "fermilab"
         if os.environ.get("_condor_COLLECTOR_HOST"):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,3 +1,12 @@
+def getschedd(s):
+    """obfuscated way to get development schedd -- works onsite"""
+    hn = os.environ["HOSTNAME"]
+    dom = hn[hn.find(".") :]
+    js = os.path.basename(os.path.dirname(os.path.dirname(__file__)))[:6]
+    n = dom.find(".", 1) - 4
+    return f"{js}{s}0{n}{dom}"
+
+
 class TestUnit:
     """
     strings/parameters common to unit tests
@@ -5,7 +14,7 @@ class TestUnit:
 
     test_group = "fermilab"
     # test_group = "dune"
-    test_schedd = "jobsubdevgpvm01.fnal.gov"
+    test_schedd = getschedd("devgpvm")
     test_vargs = {
         "debug": False,
         "executable": "file:///bin/true",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,3 +1,6 @@
+import os.path
+
+
 def getschedd(s):
     """obfuscated way to get development schedd -- works onsite"""
     hn = os.environ["HOSTNAME"]


### PR DESCRIPTION
This pull request moves all literal hostnames  into the config.d and spec subdirectories, so they can be
split out into a separate, private, Git repo.  Two of them, in the test code, are replaced by obfuscating
functions, which should still hide them from things that scan for hostnames, and will also give wrong/different
answers offsite.