### PR TITLE
make environment cleanup optional

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -259,6 +259,12 @@ def get_parser() -> argparse.ArgumentParser:
         help="generate condor_command file but do not submit",
     )
     parser.add_argument(
+        "--no-env-cleanup",
+        default=False,
+        action="store_true",
+        help="do not clean environment in wrapper script",
+    )
+    parser.add_argument(
         "--OS",
         default=None,
         help="specify OS version of worker node. Example --OS=SL5 Comma"

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -10,6 +10,7 @@ umask 002
 # add a link of our original name
 ln $0 simple.sh
 
+{% if not no_env_cleanup %}
 #
 # clear out variables that sometimes bleed into containers
 # causing problems.  See for example INC000001136681...
@@ -18,6 +19,7 @@ for env_var in CPATH LIBRARY_PATH
 do
    eval unset $env_var
 done
+{% endif %}
 
 {% if role is defined and role and role != 'Analysis' %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -134,6 +134,7 @@ def all_test_args():
         "xxmaxConcurrentxx",
         "--memory",
         "xxmemoryxx",
+        "--no-env-cleanup",
         "--no-singularity",
         "--no-submit",
         "--OS",


### PR DESCRIPTION
last tidbit for #119, #84 adding a command line option to not clear our list of bad environment variables in the wrapper. 