### PR TITLE
Arg handling and help fixup

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -102,9 +102,7 @@ def main():
         group = os.environ.get("GROUP", None)
 
     if group is None:
-        raise AttributeError(
-            f"{sys.argv[0]} needs -G group or $GROUP in the environment."
-        )
+        raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     if args.test is not None:
         schedd_name = args.test

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -55,9 +55,7 @@ def main():
     os.environ["BEARER_TOKEN_FILE"] = token
 
     if os.environ.get("GROUP", None) is None:
-        raise AttributeError(
-            f"{sys.argv[0]} needs -G group or $GROUP in the environment."
-        )
+        raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     schedd_add = get_schedd({})
 

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -46,7 +46,7 @@ class StoreGroupinEnvironment(argparse.Action):
 
 def main() -> None:
     """main line of code, proces args, etc."""
-    parser = get_parser.get_base_parser(with_jobid=True, add_condor_epilog=True)
+    parser = get_parser.get_jobid_parser(add_condor_epilog=True)
     parser.add_argument("-name", help="Set schedd name", default=None)
     parser.add_argument(
         "--jobsub_server", help="backwards compatability; ignored", default=None

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -31,6 +31,7 @@ PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(PREFIX, "lib"))
 
 import fake_ifdh
+import get_parser
 
 
 class StoreGroupinEnvironment(argparse.Action):
@@ -45,24 +46,19 @@ class StoreGroupinEnvironment(argparse.Action):
 
 def main() -> None:
     """main line of code, proces args, etc."""
-    parser = argparse.ArgumentParser(description="Condor command wrapper")
-    parser.add_argument(
-        "-G",
-        "--group",
-        help="Group/Experiment/Subgroup for priorities and accounting",
-        action=StoreGroupinEnvironment,
-    )
-    parser.add_argument(
-        "--role", help="VOMS Role for priorities and accounting", default="Analysis"
-    )
+    parser = get_parser.get_base_parser(with_jobid=True)
     parser.add_argument("-name", help="Set schedd name", default=None)
 
     arglist, passthru = parser.parse_known_args()
 
+    if arglist.jobid:
+        passthru.append(arglist.jobid)
+
+    if arglist.job_id:
+        passthru.append(arglist.job_id)
+
     if os.environ.get("GROUP", None) is None:
-        raise AttributeError(
-            f"{sys.argv[0]} needs -G group or $GROUP in the environment."
-        )
+        raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     # make list of arguments to pass to condor command:
     # - the passthru arguments from above, except if we have

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -46,8 +46,11 @@ class StoreGroupinEnvironment(argparse.Action):
 
 def main() -> None:
     """main line of code, proces args, etc."""
-    parser = get_parser.get_base_parser(with_jobid=True)
+    parser = get_parser.get_base_parser(with_jobid=True, add_condor_epilog=True)
     parser.add_argument("-name", help="Set schedd name", default=None)
+    parser.add_argument(
+        "--jobsub_server", help="backwards compatability; ignored", default=None
+    )
 
     arglist, passthru = parser.parse_known_args()
 
@@ -78,6 +81,10 @@ def main() -> None:
             i = m.group(1)
             if not i:
                 continue
+        # convert --better-analyze to -better-analyze, etc.
+        if i.startswith("--"):
+            i = i[1:]
+
         execargs.append(i)
 
     if schedd:

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -39,7 +39,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 import creds
-from get_parser import get_base_parser
+from get_parser import get_jobid_parser
 from condor import Job
 from utils import cleanup
 
@@ -52,7 +52,7 @@ def main():
     - condor_transfer_data
     - make tarball
     """
-    parser = get_base_parser(with_jobid=True)
+    parser = get_jobid_parser()
 
     parser.add_argument(
         "--destdir",

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -52,8 +52,8 @@ def main():
     - condor_transfer_data
     - make tarball
     """
-    parser = get_base_parser()
-    parser.add_argument("-J", "--jobid", help="job/submission ID", required=True)
+    parser = get_base_parser(with_jobid=True)
+
     parser.add_argument(
         "--destdir",
         "--dest-dir",
@@ -68,13 +68,19 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.jobid and not args.job_id:
+        raise SystemExit("jobid is required.")
+
+    if not args.jobid and args.job_id:
+        args.jobid = args.job_id
+
     if args.verbose:
         htcondor.set_subsystem("TOOL")
         htcondor.param["TOOL_DEBUG"] = "D_FULLDEBUG"
         htcondor.enable_debug()
 
     if os.environ.get("GROUP", None) is None:
-        raise AttributeError(
+        raise SystemExit(
             "%s needs -G group or $GROUP in the environment." % sys.argv[0]
         )
 

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -162,9 +162,7 @@ def main():
     args = parser.parse_args()
 
     if os.environ.get("GROUP", None) is None:
-        raise AttributeError(
-            f"{sys.argv[0]} needs -G group or $GROUP in the environment."
-        )
+        raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     proxy, token = get_creds(vars(args))
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -44,10 +44,11 @@ class StoreGroupinEnvironment(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-def get_base_parser() -> argparse.ArgumentParser:
+def get_base_parser(with_jobid: bool = False) -> argparse.ArgumentParser:
     """build the general jobsub command argument parser and return it"""
     parser = argparse.ArgumentParser()
     group = parser.add_argument_group("general arguments")
+
     group.add_argument(
         "-G",
         "--group",
@@ -68,6 +69,10 @@ def get_base_parser() -> argparse.ArgumentParser:
         default=False,
         help="dump internal state of program (useful for debugging)",
     )
+
+    if with_jobid:
+        parser.add_argument("-J", "--jobid", dest="jobid", help="job/submission ID")
+        parser.add_argument("job_id", nargs="?", help="job/submission ID")
 
     return parser
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -46,10 +46,9 @@ class StoreGroupinEnvironment(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-def get_base_parser(
-    with_jobid: bool = False, add_condor_epilog: bool = False
-) -> argparse.ArgumentParser:
+def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
     """build the general jobsub command argument parser and return it"""
+
     if add_condor_epilog:
         apargs = {
             "formatter_class": argparse.RawDescriptionHelpFormatter,
@@ -57,6 +56,7 @@ def get_base_parser(
         }
     else:
         apargs = {}
+
     parser = argparse.ArgumentParser(**apargs)  # type: ignore
     group = parser.add_argument_group("general arguments")
 
@@ -81,10 +81,13 @@ def get_base_parser(
         help="dump internal state of program (useful for debugging)",
     )
 
-    if with_jobid:
-        parser.add_argument("-J", "--jobid", dest="jobid", help="job/submission ID")
-        parser.add_argument("job_id", nargs="?", help="job/submission ID")
+    return parser
 
+
+def get_jobid_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
+    parser = get_base_parser(add_condor_epilog=add_condor_epilog)
+    parser.add_argument("-J", "--jobid", dest="jobid", help="job/submission ID")
+    parser.add_argument("job_id", nargs="?", help="job/submission ID")
     return parser
 
 

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -56,7 +56,7 @@ def find_all_arguments():
                 arg = arg[0:p2]
             # all of our old args with underscores have dashed versions now
             # so ignore the underscore versions.
-            if arg.find("_") == -1:
+            if arg.find("_") == -1 and arg:
                 allargs.append(arg)
                 dest[arg] = arg  # destination starts off as flag name
         if line.find('dest="') > 0 or line.find("dest='") > 0:
@@ -267,6 +267,8 @@ class TestGetParserUnit:
             # using dest table and fixing dashes
             uarg = dest[arg].replace("-", "_")
 
+            print("arg '{arg}' uarg '{uarg}'")
+
             if arg in flagargs:
                 # its a flag, just assert it
                 assert vres[uarg]
@@ -298,3 +300,10 @@ class TestGetParserUnit:
         assert "file:///bin/true" == vres["executable"]
         for i in range(4):
             assert "xx_executable_arg_%s_xx" % i in vres["exe_arguments"]
+
+    def test_get_condor_epilog(self):
+        """make sure we get the condor_q help epilog if we are jobsub_q"""
+        sys.argv[0] = "/blah/blah/jobsub_q"
+        epilog = get_parser.get_condor_epilog()
+        assert epilog.find("also condor_q arguments") == 0
+        assert epilog.find("-better-analyze") > 0

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -123,6 +123,7 @@ def all_test_args():
         "--generate-email-summary",
         "--group",
         "xxgroupxx",
+        "--jobid",
         "--log-file",
         "xxlog-filexx",
         "--lines",
@@ -231,7 +232,7 @@ class TestGetParserUnit:
         # mutually exclusive group, except for one
         # e.g. For the mutually exclusive group (--singularity-image,
         # --no-singularity), we pick one and enter it into args_exclude_list
-        args_exclude_list = ["--no-singularity", "--onsite-only"]
+        args_exclude_list = ["--no-singularity", "--onsite-only", "--jobid"]
 
         def filter_excluded(arg_list):
             _stripped_args_exclude_list = [arg.strip("-") for arg in args_exclude_list]


### PR DESCRIPTION
This pull request f1xes #122, and parts of #123, and a few other bits brought up by users, and improves
command-line backwards compatability on the non jobsub-submit wrappers.

You can now use --jobid=1234.0@schedd or 1234.0@schedd or -name schedd 1234.0 
interchangeably on all the commands that take jobid's. 

You can do any of jobsub_q --better-analyze or jobsub_q -better-analyze or condor_q -better-analyze,
ditto for -long / --long.

It also includes the condor_q --help info in jobsub_q --help, etc. 