### PR TITLE
If X509_USER_PROXY is set, we assume the proxy should live there - fix for kherner issue 

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -144,7 +144,7 @@ def getProxy(role: str = DEFAULT_ROLE, debug: int = 0) -> str:
     else:
         issuer = "fermilab"
         igroup = f"fermilab/{exp}"
-    vomsfile = f"{tmp}/x509up_{exp}_{role}_{pid}"
+    vomsfile = os.environ.get("X509_USER_PROXY", f"{tmp}/x509up_{exp}_{role}_{pid}")
     chk_cmd = f"voms-proxy-info -exists -valid 0:10 -file {vomsfile}"
 
     if debug > 0:

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -91,10 +91,25 @@ def test_getToken_fail(clear_token):
 
 @pytest.mark.unit
 def test_getProxy_good(clear_token):
-
     os.environ["GROUP"] = "fermilab"
     proxy = fake_ifdh.getProxy("Analysis")
     assert os.path.exists(proxy)
+
+
+@pytest.mark.unit
+def test_getProxy_override(clear_token, tmp_path):
+    fake_path = tmp_path / "test_proxy"
+    old_x509_user_proxy = os.environ.get("X509_USER_PROXY")
+    os.environ["X509_USER_PROXY"] = str(fake_path)
+    os.environ["GROUP"] = "fermilab"
+    proxy = fake_ifdh.getProxy("Analysis")
+    try:
+        assert proxy == str(fake_path)
+    except AssertionError:
+        raise
+    finally:
+        if old_x509_user_proxy is not None:
+            os.environ["X509_USER_PROXY"] = old_x509_user_proxy
 
 
 @pytest.mark.unit


### PR DESCRIPTION
If X509_USER_PROXY is set, we assume the proxy should live there or should be generated there