### PR TITLE
JobsubCmd classad attribute needs to be a string

### DIFF
--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -37,7 +37,7 @@ when_to_transfer_output = ON_EXIT_OR_EVICT
 notify_user = {{email_to}}
 
 # set command to user executable for jobsub_q
-+JobsubCmd = {{executable|basename}}
++JobsubCmd = "{{executable|basename}}"
 
 {% if subgroup is defined and subgroup %}
 +AccountingGroup = "group_{{group}}.{{subgroup}}.{{user}}"


### PR DESCRIPTION
Not tested, but doesn't get much simpler.