### PR TITLE
Add line in job JDF to tell condor schedd not to curtail lifetime of x509 proxy

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -67,7 +67,7 @@ def render_files(
     """use jinja to render the templates from srcdir into the dest directory
     using values dict for substitutions
     """
-    if values["verbose"] > 0:
+    if values.get("verbose", 0) > 0:
         print(f"trying to render files from {srcdir}\n")
 
     if dlist is None:
@@ -87,9 +87,9 @@ def render_files(
         if values["verbose"] > 0:
             print(f"rendering: {f}")
         bf = os.path.basename(f)
-        ff = os.path.join(dest, bf)
+        rendered_file = os.path.join(dest, bf)
         try:
-            with open(ff, "w", encoding="UTF-8") as of:
+            with open(rendered_file, "w", encoding="UTF-8") as of:
                 of.write(jinja_env.get_template(bf).render(**values))
         except jinja.exceptions.UndefinedError as e:
             err = f"""Cannot render template file {f} due to undefined template variables.
@@ -99,8 +99,11 @@ in its entirety.
 """
             print(err)
             raise
-        if ff.endswith(".sh"):
-            os.chmod(ff, 0o755)
+        if rendered_file.endswith(".sh"):
+            os.chmod(rendered_file, 0o755)
+        else:
+            if values.get("verbose", 0) > 0:
+                print(f"Created file {rendered_file}")
 
 
 def do_dataset_defaults(varg: Dict[str, Any]) -> None:

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -34,7 +34,7 @@ COLLECTOR_HOST = htcondor.param.get("COLLECTOR_HOST", None)
 
 
 # pylint: disable-next=no-member
-def get_schedd(vargs: Dict[str, str]) -> classad.ClassAd:
+def get_schedd(vargs: Dict[str, Any]) -> classad.ClassAd:
     """get jobsub* schedd names from collector, pick one."""
     # pylint: disable-next=no-member
     coll = htcondor.Collector(COLLECTOR_HOST)
@@ -45,8 +45,8 @@ def get_schedd(vargs: Dict[str, str]) -> classad.ClassAd:
     # need to directQuery for the full classads to check for
     # SupportedVOList...
 
-    if vargs.get("verbose"):
-        print("classads: ", schedd_classads)
+    if vargs.get("verbose", 0) > 1:
+        print(f"schedd classads: {schedd_classads} ")
 
     # pick schedds who do or do not have "dev" in their name, depending if
     # we have "devserver" set...

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -87,6 +87,7 @@ use_oauth_services = {{group}}
 {% else %}
 +x509userproxy = "{{proxy}}"
 {% endif %}
+delegate_job_GSI_credentials_lifetime = 0
 {% endif %}
 
 queue {{N}}


### PR DESCRIPTION
Add line in job JDF to tell condor schedd not to curtail lifetime of x509 proxy, along with a couple of verbose statements and small changes to increase readability.

Passed unit tests, and test laid out in #179.

This solves the first half of #179, but does not fix the issue with DAGs.  When #185 is completed, I will implement the same change to the DAG templates in a future PR.