### PR TITLE
JOBSUB_TEST_INSTALLED environment flag

### DIFF
--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -12,8 +12,12 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
 import condor
 
 from test_unit import TestUnit

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -11,8 +11,12 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
 import creds
 from test_unit import TestUnit
 

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -12,8 +12,12 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
 import dagnabbit
 
 from test_unit import TestUnit

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -118,7 +118,10 @@ class TestDagnabbitUnit:
         ] = "--resource-provides=usage_model=DEDICATED,OPPORTUNISTIC"
         os.environ["JOBSUB_EXPORTS"] = "--mail-on-error"
         os.environ["GROUP"] = TestUnit.test_group
-        d1 = os.path.join("..", "..", "templates", "simple")
+        if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+            d1 = "/opt/jobsub_lite/templates/simple"
+        else:
+            d1 = os.path.join("..", "..", "templates", "simple")
         # file has relative paths in it, so chdir there
         os.chdir("dagnabbit")
         varg["dag"] = 1

--- a/tests/test_decode_token_unit.py
+++ b/tests/test_decode_token_unit.py
@@ -5,11 +5,19 @@ import pytest
 import sys
 import time
 
-sys.path.append("../lib")
-import fake_ifdh
 
 # make sure we are cd-ed in the test directorectory
 os.chdir(os.path.dirname(__file__))
+
+#
+# import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
+#
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+import fake_ifdh
 
 
 def do_decode_token_sh(filename: str, extract: str = ""):

--- a/tests/test_decode_token_unit.py
+++ b/tests/test_decode_token_unit.py
@@ -27,7 +27,10 @@ def do_decode_token_sh(filename: str, extract: str = ""):
         estr = f" -e {extract} "
     else:
         estr = ""
-    cmd = f"../bin/decode_token.sh {estr}{filename}"
+    if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+        cmd = f"/opt/jobsub_lite/bin/decode_token.sh {estr}{filename}"
+    else:
+        cmd = f"../bin/decode_token.sh {estr}{filename}"
     lines = []
     with os.popen(cmd, "r") as f:
         lines = f.readlines()

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -11,8 +11,12 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
 
 import fake_ifdh
 

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -11,8 +11,13 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
 import get_parser
 
 from test_unit import TestUnit

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -49,7 +49,10 @@ def find_all_arguments(paired_arguments):
     # * we don't have more than one add_argument call per line
     # so we look for various parts of the add_argument calls
     # separately on each line
-    f = open("../lib/get_parser.py", "r")
+    if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+        f = open("/opt/jobsub_lite/lib/get_parser.py", "r")
+    else:
+        f = open("../lib/get_parser.py", "r")
     flagargs = set()
     listargs = set()
     allargs = []

--- a/tests/test_jobsub_submit_unit.py
+++ b/tests/test_jobsub_submit_unit.py
@@ -12,14 +12,24 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
 import utils
 
 from test_unit import TestUnit
 
-if not os.path.exists("jobsub_submit.py"):
-    os.symlink("../bin/jobsub_submit", "jobsub_submit.py")
+os.unlink("jobsub_submit.py")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    if not os.path.exists("jobsub_submit.py"):
+        os.symlink("/opt/jobsub_lite/bin/jobsub_submit", "jobsub_submit.py")
+else:
+    if not os.path.exists("jobsub_submit.py"):
+        os.symlink("../bin/jobsub_submit", "jobsub_submit.py")
 import jobsub_submit
 
 

--- a/tests/test_jobsub_submit_unit.py
+++ b/tests/test_jobsub_submit_unit.py
@@ -23,7 +23,10 @@ import utils
 
 from test_unit import TestUnit
 
-os.unlink("jobsub_submit.py")
+try:
+    os.unlink("jobsub_submit.py")
+except:
+    pass
 if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
     if not os.path.exists("jobsub_submit.py"):
         os.symlink("/opt/jobsub_lite/bin/jobsub_submit", "jobsub_submit.py")
@@ -51,7 +54,12 @@ class TestJobsubSubmitUnit:
     @pytest.mark.unit
     def test_render_files_1(self):
         """test render files on the dataset_dag directory"""
-        srcdir = os.path.dirname(os.path.dirname(__file__)) + "/templates/dataset_dag"
+        if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+            srcdir = "/opt/jobsub_lite/templates/dataset_dag"
+        else:
+            srcdir = (
+                os.path.dirname(os.path.dirname(__file__)) + "/templates/dataset_dag"
+            )
         dest = "/tmp/out{0}".format(os.getpid())
         os.mkdir(dest)
         args = {**TestUnit.test_vargs, **TestUnit.test_extra_template_args}
@@ -66,7 +74,10 @@ class TestJobsubSubmitUnit:
         Should raise jinja2.exceptions.UndefinedError
         """
         test_vargs = {}
-        srcdir = os.path.dirname(os.path.dirname(__file__)) + "/templates/simple"
+        if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+            srcdir = "/opt/jobsub_lite/templates/simple"
+        else:
+            srcdir = os.path.dirname(os.path.dirname(__file__)) + "/templates/simple"
         dest = tmp_path
         args = {**TestUnit.test_vargs, **TestUnit.test_extra_template_args}
         with pytest.raises(exceptions.UndefinedError, match="is undefined"):

--- a/tests/test_packages_unit.py
+++ b/tests/test_packages_unit.py
@@ -13,8 +13,13 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
 import packages
 
 

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -12,9 +12,17 @@ import shutil
 # test area, so go ahead and cd there
 #
 os.chdir(os.path.dirname(__file__))
-os.environ["PATH"] = (
-    os.path.dirname(os.path.dirname(__file__)) + "/bin:" + os.environ["PATH"]
-)
+
+#
+# add to path what we eed to test
+# unless we're testing installed, then use /opt/jobsub_lite/...
+#
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    os.environ["PATH"] = "/opt/jobsub_lite/bin:" + os.environ["PATH"]
+else:
+    os.environ["PATH"] = (
+        os.path.dirname(os.path.dirname(__file__)) + "/bin:" + os.environ["PATH"]
+    )
 
 
 @pytest.fixture

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -12,8 +12,13 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
 import tarfiles
 import get_parser
 

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -13,8 +13,13 @@ os.chdir(os.path.dirname(__file__))
 
 #
 # import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
 #
-sys.path.append("../lib")
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
 import utils
 
 from test_unit import TestUnit


### PR DESCRIPTION
Added support for doing:

JOBSUB_TEST_INSTALLED=1 pytest

to test the installed version of jobsub, rather than the copy we're sitting in.