### PR TITLE
tarfile hash repeatability fix

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -215,8 +215,17 @@ def getProxy(
     return vomsfile
 
 
+def fix_pnfs(path: str) -> str:
+    m = re.match(r"/pnfs/(.*)", path)
+    if m:
+        path = f"https://fndca1.fnal.gov:2880/{m.group(1)}"
+    return path
+
+
 def cp(src: str, dest: str) -> None:
     """copy a (remote) file with gfal-copy"""
+    src = fix_pnfs(src)
+    dest = fix_pnfs(dest)
     os.system(f"gfal-copy {src} {dest}")
 
 

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -51,7 +51,7 @@ def tar_up(directory: str, excludes: str, file: str = ".") -> str:
     if not excludes:
         excludes = os.path.dirname(__file__) + "/../etc/excludes"
     excludes = f"--exclude-from {excludes}"
-    os.system(f"tar czvf {tarfile} {excludes} --directory {directory} {file}")
+    os.system(f"GZIP=-n tar czvf {tarfile} {excludes} --directory {directory} {file}")
     return tarfile
 
 

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -42,6 +42,28 @@ class TestTarfilesUnit:
         assert len(digest) == 64
 
     @pytest.mark.unit
+    def test_repeated_tar_same_hash(self):
+        """make sure if we tar up the same data twice we get the same
+        hash for the tarball (i.e. no GZIP -n silliness)"""
+        t1 = tarfiles.tar_up(
+            os.path.dirname(__file__), "/dev/null", os.path.basename(__file__)
+        )
+        h1, b1 = tarfiles.slurp_file(t1)
+        print(f"h1: {h1}")
+        os.system(f"md5sum {t1}")
+        os.unlink(t1)
+        # wait to get a different timestamp
+        time.sleep(2)
+        t2 = tarfiles.tar_up(
+            os.path.dirname(__file__), "/dev/null", os.path.basename(__file__)
+        )
+        h2, b2 = tarfiles.slurp_file(t2)
+        print(f"h2: {h2}")
+        os.system(f"md5sum {t2}")
+        os.unlink(t2)
+        assert h1 == h2
+
+    @pytest.mark.unit
     def test_dcache_persistent_path_1(self):
         """make sure persistent path gives /pnfs/ path digest"""
         path = tarfiles.dcache_persistent_path(TestUnit.test_group, __file__)

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -113,15 +113,64 @@ class TestTarfilesUnit:
             ]
             parser = get_parser.get_parser()
             args = parser.parse_args(argv)
+            print(f"b: args.tar_file_name: {args.tar_file_name}")
             before_len = len(args.tar_file_name)
             tarfiles.do_tarballs(args)
+            print(f"a: args.tar_file_name: {args.tar_file_name}")
             assert args.tar_file_name[0][:6] == "/{0}/".format(dropbox_type)[:6]
             assert before_len == len(args.tar_file_name)
 
-    def x_test_do_tarballs_2(self):
+    @pytest.mark.unit
+    def test_do_tarballs_2(self, needs_credentials):
+        """test that the do_tarballs method does a dropbox:path
+        processing"""
+        tdir = os.path.dirname(__file__)
+        for dropbox_type in ["cvmfs", "pnfs"]:
+            print(f"dropbox type: {dropbox_type}\n===============")
+            argv = [
+                "--tar_file_name",
+                "tardir://{0}".format(tdir),
+                "--use-{0}-dropbox".format(dropbox_type),
+                "--group",
+                TestUnit.test_group,
+                "file:///bin/true",
+            ]
+            parser = get_parser.get_parser()
+            args = parser.parse_args(argv)
+            print(f"b: args.tar_file_name: {args.tar_file_name}")
+            before_len = len(args.tar_file_name)
+            tarfiles.do_tarballs(args)
+            print(f"a: args.tar_file_name: {args.tar_file_name}")
+            assert args.tar_file_name[0][:6] == "/{0}/".format(dropbox_type)[:6]
+            assert before_len == len(args.tar_file_name)
+
+    @pytest.mark.unit
+    def test_do_tarballs_3(self, needs_credentials):
+        """test that the do_tarballs method does a dropbox:path
+        processing"""
+        for dropbox_type in ["cvmfs", "pnfs"]:
+            print(f"dropbox type: {dropbox_type}\n===============")
+            argv = [
+                "-f",
+                "dropbox://{0}".format(__file__),
+                "--use-{0}-dropbox".format(dropbox_type),
+                "--group",
+                TestUnit.test_group,
+                "file:///bin/true",
+            ]
+            parser = get_parser.get_parser()
+            args = parser.parse_args(argv)
+            print(f"b: args.input_file: {args.tar_file_name}")
+            before_len = len(args.tar_file_name)
+            tarfiles.do_tarballs(args)
+            print(f"a: args.input_file: {args.tar_file_name}")
+            assert args.input_file[0][:6] == "/{0}/".format(dropbox_type)[:6]
+            assert before_len == len(args.tar_file_name)
+
+    def x_test_do_tarballs_4(self):
         # should have another one here to test dropbox:xxx
         pass
 
-    def x_test_do_tarballs_3(self):
+    def x_test_do_tarballs_5(self):
         # should have another one here to test existing /cvmfs path
         pass


### PR DESCRIPTION
[from slack channel]
vito  11:48 AM
while doing some check for jobsub_lite ticket INC000001144465 [dropbox bug] it looks like if I want to transfer a file to the job I get different hash every time I use that file, so RCDS picks up a different CVMFS path each time, is this the expected behavior?

mengel [12:09 PM]
It's supposed to be based on the md5 hash of the tarfile... but that tickles a memory: https://unix.stackexchange.com/questions/438329/tar-produces-different-files-each-time
let me see if their workaround works here...
(i.e using gzip -n when compressing the repository to omit the timestamp)

Okay that works... thus this pull request, with a test!