### PR TITLE
Fix --site flag

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -331,9 +331,6 @@ def get_parser() -> argparse.ArgumentParser:
         " '&&(CVMFS==\"OSG\")' to the job requirements",
     )
     parser.add_argument(
-        "--site", default="", help="submit jobs to these (comma-separated) sites"
-    )
-    parser.add_argument(
         "--tar_file_name",
         "--tar-file-name",
         default=[],
@@ -390,6 +387,12 @@ def get_parser() -> argparse.ArgumentParser:
     )
 
     usage_model_group = parser.add_mutually_exclusive_group()
+    usage_model_group.add_argument(
+        "--site",
+        type=str,
+        default="",
+        help="submit jobs to these (comma-separated) sites",
+    )
     usage_model_group.add_argument(
         "--onsite",
         "--onsite-only",

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -330,7 +330,9 @@ def get_parser() -> argparse.ArgumentParser:
         ' +DESIRED_CVMFS="OSG" to the job classad attributes and'
         " '&&(CVMFS==\"OSG\")' to the job requirements",
     )
-    parser.add_argument("--site", help="submit jobs to these (comma-separated) sites")
+    parser.add_argument(
+        "--site", default="", help="submit jobs to these (comma-separated) sites"
+    )
     parser.add_argument(
         "--tar_file_name",
         "--tar-file-name",

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -21,6 +21,8 @@ import re
 import sys
 from typing import Union, Any
 
+from utils import DEFAULT_USAGE_MODELS
+
 
 def verify_executable_starts_with_file_colon(s: str) -> str:
     """routine to give argparse to verify the executable parameter,
@@ -399,7 +401,7 @@ def get_parser() -> argparse.ArgumentParser:
         dest="usage_model",
         action="store_const",
         const="OPPORTUNISTIC,DEDICATED",
-        default="OPPORTUNISTIC,DEDICATED,OFFSITE",
+        default=",".join(DEFAULT_USAGE_MODELS),
         help="run jobs locally only; usage_model=OPPORTUNISTIC,DEDICATED",
     )
     usage_model_group.add_argument(
@@ -408,7 +410,7 @@ def get_parser() -> argparse.ArgumentParser:
         dest="usage_model",
         action="store_const",
         const="OFFSITE",
-        default="OPPORTUNISTIC,DEDICATED,OFFSITE",
+        default=",".join(DEFAULT_USAGE_MODELS),
         help="run jobs offsite; usage_model=OFFSITE",
     )
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -129,25 +129,28 @@ def set_extras_n_fix_units(
 
     args["resource_provides_quoted"] = [fixquote(x) for x in args["resource_provides"]]
 
+    # Setting usage_model and site keys correctly in args dict
+
     # if the user defined the usage_model on the command line,
     # we need to use their definition of usage_model, not ours
     # also, we define the site as 'Fermigrid' if they have not requested OFFSITE
-    add_site = ""
     for r in args["resource_provides_quoted"]:
         if "usage_model" in r:
             args["usage_model"] = ""
-            if "OFFSITE" not in r:
-                add_site = "Fermigrid"
+            # If a user has not specifically requested offsite, and has not specified a site, set site to Fermigrid
+            if "OFFSITE" not in r and (args.get("site", None) is None):
+                args["site"] = "Fermigrid"
 
-    # if the user chooses 'onsite' from the runtime params
-    # we need to define the sites as 'Fermigrid'
-    if args["usage_model"] != "" and "OFFSITE" not in args["usage_model"]:
-        add_site = "Fermigrid"
+    # If the user chooses 'onsite' from the runtime params, and if a user has not specifically requested offsite,
+    # and has not specified a site, set site to Fermigrid
+    if (
+        args["usage_model"] != ""
+        and "OFFSITE" not in args["usage_model"]
+        and (args.get("site", None) is None)
+    ):
+        args["site"] = "Fermigrid"
 
-    if args.get("site", None):
-        args["site"] += ", " + add_site
-    else:
-        args["site"] = add_site
+    # END site/usage_model adjustment
 
     if not "outdir" in args:
         args["outdir"] = f"{args['outbase']}/js_{args['date']}_{args['uuid']}"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -363,8 +363,8 @@ def resolve_site_and_usage_model(
         for request in resource_provides:
             if usage_model_regex.match(request):
                 msg = (
-                    "As --site or --onsite/--offsite were provided, we will "
-                    "ignore the usage_model designation in --resource-provides "
+                    "Warning:  As --site or --onsite/--offsite were provided, we will "
+                    "ignore this usage_model designation in --resource-provides: "
                     f"{request}."
                 )
                 print(msg)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -431,7 +431,12 @@ def resolve_site_and_usage_model(
         usage_model_matches = usage_model_regex.match(request)
         if usage_model_matches:
             # Found usage_model in --resource-provides.  Don't set usage_model. Template will read it from --resource-provides
-            derived_usage_models = usage_model_matches.group(1).split(",")
+            # Note that when resource_provides_quoted is created, something like:
+            #     --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC
+            # is stored in resource_provides_quoted as:
+            #     ['usage_model="DEDICATED,OPPORTUNISTIC"']
+            # We need to remove those extra quotes around the "DEDICATED,OPPORTUNISTIC" to properly parse the usage models
+            derived_usage_models = usage_model_matches.group(1).strip('"').split(",")
             if ("OFFSITE" not in derived_usage_models) and given_sites == "":
                 # If they've only asked for onsite, add Fermigrid in the sites list.  Not entirely necessary,
                 # but it makes explicit what the user has asked for

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -44,7 +44,8 @@ notify_user = {{email_to}}
 {% endif %}
 {{resource_provides_quoted|join("\n+DESIRED_")}}
 {{lines|join("\n")}}
-requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements is defined  and append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
+requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2 && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%if site is defined and site != '' %} && ((isUndefined(target.GLIDEIN_Site) == FALSE) && (stringListIMember(target.GLIDEIN_Site,my.DESIRED_Sites))){%endif%}{%if append_condor_requirements is defined and append_condor_requirements %} && {{append_condor_requirements}}{%endif%}
+
 
 {% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -45,7 +45,7 @@ notify_user = {{email_to}}
 {% endif %}
 {{resource_provides_quoted|join("\n+DESIRED_")}}
 {{lines|join("\n")}}
-requirements  = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))) {%if append_condor_requirements is defined and append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
+requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2 && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%if site is defined and site != '' %} && ((isUndefined(target.GLIDEIN_Site) == FALSE) && (stringListIMember(target.GLIDEIN_Site,my.DESIRED_Sites))){%endif%}{%if append_condor_requirements is defined and append_condor_requirements %} && {{append_condor_requirements}}{%endif%}
 
 {% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -61,7 +61,8 @@ notify_user = {{email_to}}
 {% endif %}
 {{resource_provides_quoted|join("\n+DESIRED_")}}
 {{lines|join("\n")}}
-requirements  = {%if overwrite_requirements is defined and overwrite_requirements %}{{overwrite_requirements}}{%else%}target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2  && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%endif%}{%if append_condor_requirements is defined and append_condor_requirements %} && {{append_condor_requirements}} {%endif%}
+requirements  = {%if overwrite_requirements is defined and overwrite_requirements %}{{overwrite_requirements}}{%else%}target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2 && (isUndefined(DesiredOS) || stringListsIntersect(toUpper(DesiredOS),IFOS_installed)) && (stringListsIntersect(toUpper(target.HAS_usage_model), toUpper(my.DESIRED_usage_model))){%if site is defined and site != '' %} && ((isUndefined(target.GLIDEIN_Site) == FALSE) && (stringListIMember(target.GLIDEIN_Site,my.DESIRED_Sites))){%endif%}{%endif%}{%if append_condor_requirements is defined and append_condor_requirements %} && {{append_condor_requirements}}{%endif%}
+
 
 {% if no_singularity is false %}
 +SingularityImage="{{singularity_image}}"

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -271,6 +271,7 @@ class TestGetParserUnit:
             "--onsite",
             "--onsite-only",
             "--offsite-only",
+            "--offsite",
             "--jobid",
         ]
 

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -168,3 +168,234 @@ class TestUtilsUnit:
         assert not os.path.exists(f"{test_old_dir}/simple.cmd")
         assert not os.path.exists(f"{oldd}/simple.cmd")
         assert os.path.exists(f"{newd}/simple.cmd")
+
+    @pytest.mark.unit
+    def test_resolve_site_and_usage_model(self):
+        _should_work = [
+            # no flags
+            (
+                "",
+                "DEDICATED,OPPORTUNISTIC,OFFSITE",
+                [],
+                (
+                    utils.SiteAndUsageModel("", "DEDICATED,OPPORTUNISTIC,OFFSITE"),
+                    [],
+                ),
+            ),
+            # --onsite
+            (
+                "",
+                "DEDICATED,OPPORTUNISTIC",
+                [],
+                (
+                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    [],
+                ),
+            ),
+            # --site Fermigrid
+            (
+                utils.ONSITE_SITE_NAME,
+                "",
+                [],
+                (
+                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    [],
+                ),
+            ),
+            # --site Random_Site
+            (
+                "Random_Site",
+                "",
+                [],
+                (
+                    utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --offsite
+            (
+                "",
+                "OFFSITE",
+                [],
+                (
+                    utils.SiteAndUsageModel("", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --resource-provides=usage_model=DEDICATED,OFFSITE
+            (
+                "",
+                "",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel("", ""),
+                    ["usage_model=DEDICATED,OFFSITE"],
+                ),
+            ),
+            # --resource-provides=usage_model=DEDICATED,OFFSITE --site Fermigrid
+            (
+                utils.ONSITE_SITE_NAME,
+                "",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    [],
+                ),
+            ),
+            # --resource-provides=usage_model=DEDICATED,OFFSITE --site Random_Site
+            (
+                "Random_Site",
+                "",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --site=Fermigrid,Random_Site --resource-provides=usage_model=DEDICATED,OFFSITE
+            (
+                f"{utils.ONSITE_SITE_NAME},Random_Site",
+                "",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel(
+                        f"{utils.ONSITE_SITE_NAME},Random_Site",
+                        "DEDICATED,OPPORTUNISTIC,OFFSITE",
+                    ),
+                    [],
+                ),
+            ),
+            # --site=Fermigrid,Random_Site
+            (
+                f"{utils.ONSITE_SITE_NAME},Random_Site",
+                "",
+                [],
+                (
+                    utils.SiteAndUsageModel(
+                        f"{utils.ONSITE_SITE_NAME},Random_Site",
+                        "DEDICATED,OPPORTUNISTIC,OFFSITE",
+                    ),
+                    [],
+                ),
+            ),
+            # --site=Fermigrid,Random_Site --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource
+            (
+                f"{utils.ONSITE_SITE_NAME},Random_Site",
+                "",
+                ["usage_model=DEDICATED,OFFSITE", "IWANT=this_resource"],
+                (
+                    utils.SiteAndUsageModel(
+                        f"{utils.ONSITE_SITE_NAME},Random_Site",
+                        "DEDICATED,OPPORTUNISTIC,OFFSITE",
+                    ),
+                    ["IWANT=this_resource"],
+                ),
+            ),
+            # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource
+            (
+                "",
+                "DEDICATED,OPPORTUNISTIC",
+                ["usage_model=DEDICATED,OFFSITE", "IWANT=this_resource"],
+                (
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
+                    ["IWANT=this_resource"],
+                ),
+            ),
+            # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE
+            (
+                "",
+                "DEDICATED,OPPORTUNISTIC",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
+                    [],
+                ),
+            ),
+            # --resource_provides=usage_model=DEDICATED,OPPORTUNISTIC --site Random_Site
+            (
+                "Random_Site",
+                "",
+                ["usage_model=DEDICATED,OPPORTUNISTIC"],
+                (
+                    utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --resource-provides=usage_model=DEDICATED --site Random_Site
+            (
+                "Random_Site",
+                "",
+                ["usage_model=DEDICATED"],
+                (
+                    utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --resource-provides=usage_model=OFFSITE --site Fermigrid
+            (
+                utils.ONSITE_SITE_NAME,
+                "",
+                ["usage_model=OFFSITE"],
+                (
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
+                    [],
+                ),
+            ),
+            # --site=Random_Site_1,Random_Site_2 --resource-provides=usage_model=DEDICATED,OFFSITE
+            (
+                "Random_Site_1,Random_Site_2",
+                "",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel("Random_Site_1,Random_Site_2", "OFFSITE"),
+                    [],
+                ),
+            ),
+            # --onsite --resource-provides=usage_model=DEDICATED,OFFSITE
+            (
+                "",
+                "DEDICATED,OPPORTUNISTIC",
+                ["usage_model=DEDICATED,OFFSITE"],
+                (
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
+                    [],
+                ),
+            ),
+            # --offsite --resource-provides=usage_model=DEDICATED
+            (
+                "",
+                "OFFSITE",
+                ["usage_model=DEDICATED"],
+                (
+                    utils.SiteAndUsageModel("", "OFFSITE"),
+                    [],
+                ),
+            ),
+        ]
+
+        for (sites, usage_model, resource_provides_quoted, expected) in _should_work:
+            assert (
+                utils.resolve_site_and_usage_model(
+                    sites, usage_model, resource_provides_quoted
+                )
+                == expected
+            )
+
+        # I honestly can't think of any combos that don't work/won't get corrected before we get to validation,
+        # but I'm leaving this here unless I missed something
+        _should_not_work = []
+        for (sites, usage_model, resource_provides_quoted) in _should_not_work:
+            with pytest.raises(
+                utils.SiteAndUsageModelConflictError, match="are in conflict"
+            ):
+                utils.resolve_site_and_usage_model(
+                    sites, usage_model, resource_provides_quoted
+                )

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -230,17 +230,17 @@ class TestUtilsUnit:
             (
                 "",
                 "",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel("", ""),
-                    ["usage_model=DEDICATED,OFFSITE"],
+                    ['usage_model="DEDICATED,OFFSITE"'],
                 ),
             ),
             # --resource-provides=usage_model=DEDICATED,OFFSITE --site Fermigrid
             (
                 utils.ONSITE_SITE_NAME,
                 "",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
@@ -252,7 +252,7 @@ class TestUtilsUnit:
             (
                 "Random_Site",
                 "",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
@@ -262,7 +262,7 @@ class TestUtilsUnit:
             (
                 f"{utils.ONSITE_SITE_NAME},Random_Site",
                 "",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel(
                         f"{utils.ONSITE_SITE_NAME},Random_Site",
@@ -288,32 +288,32 @@ class TestUtilsUnit:
             (
                 f"{utils.ONSITE_SITE_NAME},Random_Site",
                 "",
-                ["usage_model=DEDICATED,OFFSITE", "IWANT=this_resource"],
+                ['usage_model="DEDICATED,OFFSITE"', 'IWANT="this_resource"'],
                 (
                     utils.SiteAndUsageModel(
                         f"{utils.ONSITE_SITE_NAME},Random_Site",
                         "DEDICATED,OPPORTUNISTIC,OFFSITE",
                     ),
-                    ["IWANT=this_resource"],
+                    ['IWANT="this_resource"'],
                 ),
             ),
             # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource
             (
                 "",
                 "DEDICATED,OPPORTUNISTIC",
-                ["usage_model=DEDICATED,OFFSITE", "IWANT=this_resource"],
+                ['usage_model="DEDICATED,OFFSITE"', 'IWANT="this_resource"'],
                 (
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
-                    ["IWANT=this_resource"],
+                    ['IWANT="this_resource"'],
                 ),
             ),
             # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE
             (
                 "",
                 "DEDICATED,OPPORTUNISTIC",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
@@ -325,7 +325,7 @@ class TestUtilsUnit:
             (
                 "Random_Site",
                 "",
-                ["usage_model=DEDICATED,OPPORTUNISTIC"],
+                ['usage_model="DEDICATED,OPPORTUNISTIC"'],
                 (
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
@@ -335,7 +335,7 @@ class TestUtilsUnit:
             (
                 "Random_Site",
                 "",
-                ["usage_model=DEDICATED"],
+                ['usage_model="DEDICATED"'],
                 (
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
@@ -345,7 +345,7 @@ class TestUtilsUnit:
             (
                 utils.ONSITE_SITE_NAME,
                 "",
-                ["usage_model=OFFSITE"],
+                ['usage_model="OFFSITE"'],
                 (
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
@@ -357,7 +357,7 @@ class TestUtilsUnit:
             (
                 "Random_Site_1,Random_Site_2",
                 "",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel("Random_Site_1,Random_Site_2", "OFFSITE"),
                     [],
@@ -367,7 +367,7 @@ class TestUtilsUnit:
             (
                 "",
                 "DEDICATED,OPPORTUNISTIC",
-                ["usage_model=DEDICATED,OFFSITE"],
+                ['usage_model="DEDICATED,OFFSITE"'],
                 (
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
@@ -379,7 +379,7 @@ class TestUtilsUnit:
             (
                 "",
                 "OFFSITE",
-                ["usage_model=DEDICATED"],
+                ['usage_model="DEDICATED"'],
                 (
                     utils.SiteAndUsageModel("", "OFFSITE"),
                     [],

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -188,7 +188,9 @@ class TestUtilsUnit:
                 "DEDICATED,OPPORTUNISTIC",
                 [],
                 (
-                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
                     [],
                 ),
             ),
@@ -198,7 +200,9 @@ class TestUtilsUnit:
                 "",
                 [],
                 (
-                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
                     [],
                 ),
             ),
@@ -238,7 +242,9 @@ class TestUtilsUnit:
                 "",
                 ["usage_model=DEDICATED,OFFSITE"],
                 (
-                    utils.SiteAndUsageModel("Fermigrid", "DEDICATED,OPPORTUNISTIC"),
+                    utils.SiteAndUsageModel(
+                        utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
+                    ),
                     [],
                 ),
             ),


### PR DESCRIPTION
There's a lot here.  This is a summary of the changes.

1.  --site now works
2. --site defaults to "", not None
3. --site is mutually exclusive with --onsite/--offsite flags
4. As described in #198, there is new logic on how --site, --onsite/offsite, and --resource-provides=usage_model is handled.  The summary is here:  https://github.com/marcmengel/jobsub_lite/issues/198#issuecomment-1363266689 .  We basically give precedence to --site, then --onsite/offsite, then --resource-provides=usage_model.
5. Changed templates to select site properly

I've requested all three of you to check this:
@goodenou: this reimplements the logic you had before, but slightly changed.  Please make sure it makes sense to you, both from a technical and as FIFE lead in terms of policy.
@retzkek: (3) above - does it look right to you?
@marcmengel:  Testing.  I've done a lot of testing of this PR, (see #198), but would you be able to check it with DAGs?  I've done some basic DAG testing, but it's not really my forte.

Of course, as of this writing, everyone's on vacation, so please feel free to review this when you're back.

Thanks all!

Closes #198 
