### PR TITLE
draft of --line backslash compatability

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -109,7 +109,7 @@ def set_extras_n_fix_units(
     args["kerberos_principal"] = get_principal()
     args["uid"] = str(os.getuid())
 
-    for i in range(len(args["line"])):
+    for i in range(len(args["lines"])):
         # do 1 layer of \x -> x to be compatible with jobsub_client
         args["lines"][i] = re.sub(r"\\(.)", "\\1", args["lines"][i])
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -109,6 +109,10 @@ def set_extras_n_fix_units(
     args["kerberos_principal"] = get_principal()
     args["uid"] = str(os.getuid())
 
+    for i in range(len(args["line"])):
+        # do 1 layer of \x -> x to be compatible with jobsub_client
+        args["line"][i] = re.sub(r"\\(.)", "\\1", args["line"][i])
+
     if not "uuid" in args:
         args["uuid"] = str(uuid.uuid4())
     if not "date" in args:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -111,7 +111,7 @@ def set_extras_n_fix_units(
 
     for i in range(len(args["line"])):
         # do 1 layer of \x -> x to be compatible with jobsub_client
-        args["line"][i] = re.sub(r"\\(.)", "\\1", args["line"][i])
+        args["lines"][i] = re.sub(r"\\(.)", "\\1", args["lines"][i])
 
     if not "uuid" in args:
         args["uuid"] = str(uuid.uuid4())


### PR DESCRIPTION
In jobsub_client, one needs to backslash quotes, etc. in  the --lines values. 