### PR TITLE
do backslash-escape processing on all args, not just --lines

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -48,7 +48,7 @@ from get_parser import get_parser
 from condor import get_schedd, submit, submit_dag
 from dagnabbit import parse_dagnabbit
 from tarfiles import do_tarballs
-from utils import set_extras_n_fix_units, cleanup
+from utils import set_extras_n_fix_units, cleanup, backslash_escape_layer
 from creds import get_creds
 from token_mods import get_job_scopes, use_token_copy
 
@@ -168,6 +168,9 @@ def main():
     """
     # pylint: disable=too-many-statements
     parser = get_parser()
+    # old jobsub_client commands got run through a shell that replaced \x with x
+    # so we do that here for backwards compatability
+    backslash_escape_layer(sys.argv)
     args = parser.parse_args()
 
     if os.environ.get("GROUP", None) is None:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -70,6 +70,13 @@ def grep_n(regex: str, n: int, file: str) -> str:
     return ""
 
 
+def backslash_escape_layer(argv: List[str]) -> None:
+    r"""do 1 layer of \x -> x to be compatible with jobsub_client"""
+
+    for i in range(len(argv)):
+        argv[i] = re.sub(r"\\(.)", "\\1", argv[i])
+
+
 def set_extras_n_fix_units(
     args: Dict[str, Any],
     schedd_name: str,
@@ -108,10 +115,6 @@ def set_extras_n_fix_units(
     args["jobsub_version"] = "lite_v1_0"
     args["kerberos_principal"] = get_principal()
     args["uid"] = str(os.getuid())
-
-    for i in range(len(args["lines"])):
-        # do 1 layer of \x -> x to be compatible with jobsub_client
-        args["lines"][i] = re.sub(r"\\(.)", "\\1", args["lines"][i])
 
     if not "uuid" in args:
         args["uuid"] = str(uuid.uuid4())


### PR DESCRIPTION
This is round 2 of addressing the compatability issue that Heidi brought up.  
In the old jobsub_client, the jobsub_submit arguments were sent over to the server, and
then the server ran a server-side jobsub_submit script locally, which involved running
another shell, and an extra eval-layer of substituting backslash-whatever. 
This happened to all of the command-line arguments, so here we do the whole of sys.argv. 