### PR TITLE
adding version and help email to jobsub_ arguments

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -34,6 +34,7 @@ import fake_ifdh
 import get_parser
 import version
 
+
 class StoreGroupinEnvironment(argparse.Action):
     """Action to store the given group in the GROUP environment variable"""
 
@@ -64,7 +65,7 @@ def main() -> None:
     if arglist.version:
         print(f"jobsub_lite version {version.__version__}")
         exit()
-        
+
     if arglist.support_email:
         print(f"Email {version.__email__} for help.")
         exit()

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -32,7 +32,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 
 import fake_ifdh
 import get_parser
-
+import version
 
 class StoreGroupinEnvironment(argparse.Action):
     """Action to store the given group in the GROUP environment variable"""
@@ -60,6 +60,14 @@ def main() -> None:
         parser.add_argument("--user", help="username to query", default=None)
 
     arglist, passthru = parser.parse_known_args()
+
+    if arglist.version:
+        print(f"jobsub_lite version {version.__version__}")
+        exit()
+        
+    if arglist.support_email:
+        print(f"Email {version.__email__} for help.")
+        exit()
 
     if cmd != "jobsub_q":
         arglist.user = None

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -74,7 +74,7 @@ def main():
     if args.version:
         print(f"jobsub_lite version {version.__version__}")
         exit()
-	
+
     if args.support_email:
         print(f"Email {version.__email__} for help.")
         exit()

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -39,6 +39,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 import creds
+import version
 from get_parser import get_jobid_parser
 from condor import Job
 from utils import cleanup
@@ -69,6 +70,14 @@ def main():
     parser.add_argument("job_id", nargs="?", help="job/submission ID")
 
     args = parser.parse_args()
+
+    if args.version:
+        print(f"jobsub_lite version {version.__version__}")
+        exit()
+	
+    if args.support_email:
+        print(f"Email {version.__email__} for help.")
+        exit()
 
     if not args.jobid and not args.job_id:
         raise SystemExit("jobid is required.")

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -51,6 +51,7 @@ from tarfiles import do_tarballs
 from utils import set_extras_n_fix_units, cleanup
 from creds import get_creds
 from token_mods import get_job_scopes, use_token_copy
+import version
 
 
 def get_basefiles(dlist: List[str]) -> List[str]:
@@ -169,6 +170,14 @@ def main():
     # pylint: disable=too-many-statements
     parser = get_parser()
     args = parser.parse_args()
+
+    if args.version:
+        print(f"jobsub_lite version {version.__version__}")
+        exit()
+
+    if args.support_email:
+        print(f"Email {version.__email__} for help.")
+        exit()
 
     if os.environ.get("GROUP", None) is None:
         raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -107,7 +107,7 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
         help="dump internal state of program (useful for debugging)",
     )
     group.add_argument(
-        "--version",        
+        "--version",
         action="store_true",
         help="version of jobsub_lite being used",
         default=False,

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -106,6 +106,18 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
         nargs=0,
         help="dump internal state of program (useful for debugging)",
     )
+    group.add_argument(
+        "--version",        
+        action="store_true",
+        help="version of jobsub_lite being used",
+        default=False,
+    )
+    group.add_argument(
+        "--support-email",
+        action="store_true",
+        help="jobsub_lite support email",
+        default=False,
+    )
     return parser
 
 

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,0 +1,26 @@
+# COPYRIGHT 2023 FERMI NATIONAL ACCELERATOR LABORATORY
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__title__ = "jobsub_lite"
+__summary__ = "The local HTCondor job submission software for Fermilab users to submit jobs to local FermiGrid resources and to the Open Science Grid."
+__uri__ = "https://fifewiki.fnal.gov/wiki/Jobsub_Lite"
+
+__version__ = "0.3"
+__email__ = "jobsub-support@fnal.gov"
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Fermi National Accelerator Laboratory"
+__copyright__ = "2023 %s" % __author__


### PR DESCRIPTION
I added arguments "--version" and ""support-email" to the list of base arguments so that folks can now submit a command such as "jobsub_fetchlog --version" and get the following output back "jobsub_lite version 0.3". The version is stored in lib/version.oy.