### PR TITLE
allow short, medium, long for duration flags --timeout and --expected_lifetime

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -172,6 +172,17 @@ def set_extras_n_fix_units(
         args["full_executable"] = dest
 
     #
+    # allow short, medium, and long for duration values (--expected_lifetime, --timeout)
+    #
+    time_aliases: Dict[str, str] = {
+        "short": "3h",
+        "med": "8h",
+        "long": "85200s",
+    }
+    for k in ("expected_lifetime", "timeout"):
+        if args[k] in time_aliases:
+            args[k] = time_aliases[args[k]]
+    #
     # conversion factors for memory suffixes
     #
     dsktable: Dict[str, float] = {

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -176,7 +176,7 @@ def set_extras_n_fix_units(
     #
     time_aliases: Dict[str, str] = {
         "short": "3h",
-        "med": "8h",
+        "medium": "8h",
         "long": "85200s",
     }
     for k in ("expected_lifetime", "timeout"):


### PR DESCRIPTION
backwards compatability.
Small change in fix_units_... code.