### PR TITLE
Lower-case all instances of role in templates when being used for oauth specification

### DIFF
--- a/templates/dag/dag.dag.condor.sub
+++ b/templates/dag/dag.dag.condor.sub
@@ -39,8 +39,8 @@ delegate_job_GSI_credentials_lifetime = 0
 +JobsubJobId="$(CLUSTER).$(PROCESS)@{{schedd}}"
 
 {% if role is defined and role and role != 'Analysis' %}
-use_oauth_services = {{group}}_{{role}}
-#{{group}}_{{role}}_oauth_permissions = "{{job_scope}}"
+use_oauth_services = {{group}}_{{role | lower}}
+#{{group}}_{{role | lower}}_oauth_permissions = "{{job_scope}}"
 {% else %}
 use_oauth_services = {{group}}
 #{{group}}_oauth_permissions = "{{job_scope}}"

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -53,8 +53,8 @@ requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= Mach
 
 # Credentials
 {% if role is defined and role and role != 'Analysis' %}
-use_oauth_services = {{group}}_{{role}}
-#{{group}}_{{role}}_oauth_permissions = "{{job_scope}}"
+use_oauth_services = {{group}}_{{role | lower}}
+#{{group}}_{{role | lower}}_oauth_permissions = "{{job_scope}}"
 {% else %}
 use_oauth_services = {{group}}
 #{{group}}_oauth_permissions = "{{job_scope}}"

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -53,8 +53,8 @@ requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= Mach
 
 # Credentials
 {% if role is defined and role and  role != 'Analysis' %}
-use_oauth_services = {{group}}_{{role}}
-#{{group}}_{{role}}_oauth_permissions = "{{job_scope}}"
+use_oauth_services = {{group}}_{{role | lower}}
+#{{group}}_{{role | lower}}_oauth_permissions = "{{job_scope}}"
 {% else %}
 use_oauth_services = {{group}}
 #{{group}}_oauth_permissions = "{{job_scope}}"

--- a/templates/dataset_dag/dataset.dag.condor.sub
+++ b/templates/dataset_dag/dataset.dag.condor.sub
@@ -39,8 +39,8 @@ environment	= _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address;
 
 # Credentials
 {% if role is defined and role and role != 'Analysis' %}
-use_oauth_services = {{group}}_{{role}}
-#{{group}}_{{role}}_oauth_permissions = "{{job_scope}}"
+use_oauth_services = {{group}}_{{role | lower}}
+#{{group}}_{{role | lower}}_oauth_permissions = "{{job_scope}}"
 {% else %}
 use_oauth_services = {{group}}
 #{{group}}_oauth_permissions = "{{job_scope}}"

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -78,9 +78,9 @@ requirements  = {%if overwrite_requirements is defined and overwrite_requirement
 
 # Credentials
 {% if role is defined and role != 'Analysis' %}
-use_oauth_services = {{group}}_{{role}}
+use_oauth_services = {{group}}_{{role | lower}}
 {% if job_scope is defined and job_scope %}
-#{{group}}_{{role}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
+#{{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% endif %}
 {% else %}
 use_oauth_services = {{group}}


### PR DESCRIPTION
@rlcee's testing with POMS showed that we neglected to lower-case the user-provided role in the templates.  We do when getting tokens, but then keep the original form for the templates.  This eventually prevents jobs from starting, as the condor_schedd looks for the credential in the form group_role.use.  If "role" is wrong, then the condor_schedd cannot find the credential, and thus the job never starts.  This can be seen in the ShadowLog.