### PR TITLE
code to read a default role

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -21,6 +21,7 @@
 
 import argparse
 import json
+import glob
 import os
 import re
 import shlex
@@ -56,6 +57,19 @@ def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
 
     if role_override:
         return role_override
+
+    # if we have a default role pushed with a vault token, or $HOME/.jobsub_default... use that
+    uid = os.getuid()
+    group = os.environ["GROUP"]
+
+    for prefix in ["/tmp/", f"{os.environ['HOME']}/."]:
+
+        fname = f"{prefix}jobsub_default_role_{group}_{uid}"
+
+        if os.path.exists(fname) and os.stat(fname).st_uid == uid:
+            with open(fname, "r") as f:
+                role = f.read().strip()
+            return role
 
     # if there's a role in the wlcg.groups of the token, pick that
     if os.environ.get("BEARER_TOKEN_FILE", False):

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -21,7 +21,6 @@
 
 import argparse
 import json
-import glob
 import os
 import re
 import shlex

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -61,7 +61,7 @@ def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
     uid = os.getuid()
     group = os.environ["GROUP"]
 
-    for prefix in ["/tmp/", f"{os.environ['HOME']}/."]:
+    for prefix in ["/tmp/", f"{os.environ['HOME']}/.config/"]:
 
         fname = f"{prefix}jobsub_default_role_{group}_{uid}"
 


### PR DESCRIPTION
Allow for a default role file to be read in that either the managed token service could push
or the user could add.   It is either:
`/tmp/jobsub_default_role_${GROUP}_$(id -u)`
or
`$HOME/.jobsub_default_role_${GROUP}_$(id -u)` 
and should contain the role (i.e. "Analysis" or "Production") 