### PR TITLE
Lowercase role for BEARER_TOKEN_FILE setting in wrapper scripts

### DIFF
--- a/templates/dag/dagman_wrapper.sh
+++ b/templates/dag/dagman_wrapper.sh
@@ -4,7 +4,7 @@
 # want it to run the local one, so we give it this one...
 
 {% if role is defined and role and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role | lower}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -52,7 +52,7 @@ requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= Mach
 {% endif %}
 
 # Credentials
-{% if role is defined and role and  role != 'Analysis' %}
+{% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 #{{group}}_{{role | lower}}_oauth_permissions = "{{job_scope}}"
 {% else %}

--- a/templates/dataset_dag/dagman_wrapper.sh
+++ b/templates/dataset_dag/dagman_wrapper.sh
@@ -3,8 +3,8 @@
 # condor wants to copy in the condor_dagman executable, but we
 # want it to run the local one, so we give it this one...
 
-{% if role is defined and role  and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role}}.use
+{% if role is defined and role and role != 'Analysis' %}
+export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}_{{role | lower}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$_CONDOR_CREDS/{{group}}.use
 {% endif %}

--- a/templates/dataset_dag/sambegin.sh
+++ b/templates/dataset_dag/sambegin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 {% if role and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}

--- a/templates/dataset_dag/samend.sh
+++ b/templates/dataset_dag/samend.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 {% if role and role != 'Analysis' %}
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -22,8 +22,8 @@ done
 {% endif %}
 
 {% if role is defined and role and role != 'Analysis' %}
-#export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}_{{oauth_handle}}.use
-export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role}}.use
+#export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}_{{oauth_handle}}.use
+export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 {% else %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{oauth_handle}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use


### PR DESCRIPTION
This is from @rlcee's issue he brought up today - I forgot to lowercase the roles in the wrapper script templates (I did for the job submission file templates).