### PR TITLE
Added warning about grid-accessibility for -f argument

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -229,7 +229,9 @@ def get_parser() -> argparse.ArgumentParser:
         " $CONDOR_DIR_INPUT/file.xxx Specify as many"
         " -f INPUT_FILE_1 -f INPUT_FILE_2 args as you need. To copy file at"
         " submission time instead of run time, use -f dropbox://INPUT_FILE"
-        " to copy the file.",
+        " to copy the file.  If -f is used without the dropbox:// URI, for"
+        " example -f /path/to/myfile, then the file (/path/to/myfile in this"
+        " example) MUST be grid-accessible via ifdh.",
     )
     parser.add_argument(
         "--generate-email-summary",

--- a/man/man1/jobsub_submit.1
+++ b/man/man1/jobsub_submit.1
@@ -127,6 +127,9 @@ be copied to $CONDOR_DIR_INPUT/file.xxx Specify as
 many -f INPUT_FILE_1 -f INPUT_FILE_2 args as you need.
 To copy file at submission time instead of run time,
 use -f dropbox://INPUT_FILE to copy the file.
+If -f is used without the dropbox:// URI, for
+example -f /path/to/myfile, then the file (/path/to/myfile
+in this example) MUST be grid-accessible via ifdh.
 .HP
 --generate-email-summary
 generate and mail a summary report of


### PR DESCRIPTION
Noted that in example `-f /path/to/myfile`, `/path/to/myfile` must be grid-accessible via ifdh.