### PR TITLE
remove +Owner lines from submit files

### DIFF
--- a/templates/dag/dag.dag.condor.sub
+++ b/templates/dag/dag.dag.condor.sub
@@ -21,7 +21,6 @@ environment	=  _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address
 
 +JobsubClientDN="{{clientdn}}"
 +JobsubClientIpAddress="{{ipaddr}}"
-+Owner="{{user}}"
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -22,7 +22,6 @@ transfer_output_files = .empty_file
 request_memory = 100mb
 +JobsubClientDN="{{clientdn}}"
 +JobsubClientIpAddress="{{ipaddr}}"
-+Owner="{{user}}"
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -23,7 +23,6 @@ when_to_transfer_output = ON_EXIT_OR_EVICT
 request_memory = 100mb
 +JobsubClientDN="{{clientdn}}"
 +JobsubClientIpAddress="{{ipaddr}}"
-+Owner="{{user}}"
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"

--- a/templates/dataset_dag/dataset.dag.condor.sub
+++ b/templates/dataset_dag/dataset.dag.condor.sub
@@ -21,7 +21,6 @@ environment	= _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address;
 
 +JobsubClientDN="{{clientdn}}"
 +JobsubClientIpAddress="{{ipaddr}}"
-+Owner="{{user}}"
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -29,7 +29,6 @@ when_to_transfer_output = ON_EXIT_OR_EVICT
 {%if     OS is defined and OS %}+DesiredOS={{OS}}{%endif%}
 +JobsubClientDN="{{clientdn}}"
 +JobsubClientIpAddress="{{ipaddr}}"
-+Owner="{{user}}"
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -52,7 +52,6 @@ request_memory = 2048.0
 request_disk = 102400.0KB
 +JobsubClientDN=""
 +JobsubClientIpAddress="131.225.67.71"
-+Owner="{user}"
 +JobsubServerVersion="lite_v1_0"
 +JobsubClientVersion="lite_v1_0"
 +JobsubClientKerberosPrincipal=""


### PR DESCRIPTION
Per Joe Boyd, we don't need to set +Owner anymore, that's an artifact of old jobsub, where everything was really submitted by rexbatch who was a superuser, and then setting +Owner made the job run as the original user...