### PR TITLE
Changed disk default to 35GB to be inline with jobsub_client default

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -165,7 +165,7 @@ def get_parser() -> argparse.ArgumentParser:
         " If UNITS is not specified default is 'KB' (a typo in earlier"
         " versions said that default was 'MB', this was wrong)."
         " Allowed values for UNITS are 'KB','MB','GB', and 'TB'",
-        default="100MB",
+        default="35GB",
     )
     parser.add_argument(
         "-d",


### PR DESCRIPTION
Fixes #262 

Unit tests pass.

Also, with the following jobsub_submit command:

```$ jobsub_submit -G fermilab -n file:///usr/bin/true```

We get the following request disk in the submit file:
```
$ grep -i disk  /home/sbhat/.cache/jobsub_lite/js_2023_02_03_035632_9fe6ea25-f37d-4135-9de8-72a5deec130d/simple.cmd 
request_disk = 36700160.0KB
```

So that works.