### PR TITLE
Set role in args dict from return value of fake_ifdh.getRole

### DIFF
--- a/lib/creds.py
+++ b/lib/creds.py
@@ -27,6 +27,7 @@ def get_creds(args: Dict[str, Any] = {}) -> Tuple[str, str]:
     """
 
     role = fake_ifdh.getRole(args.get("role", None))
+    args["role"] = role
     p = fake_ifdh.getProxy(role, args.get("verbose", 0), args.get("force_proxy", False))
     t = fake_ifdh.getToken(role, args.get("verbose", 0))
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -88,7 +88,8 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
         default=os.environ.get("GROUP", None),
     )
     group.add_argument(
-        "--role", help="VOMS Role for priorities and accounting", default="Analysis"
+        "--role",
+        help="VOMS Role for priorities and accounting",
     )
     group.add_argument(
         "--subgroup",

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -54,3 +54,12 @@ class TestCredUnit:
         assert os.path.exists(os.environ["BEARER_TOKEN_FILE"])
         assert os.path.exists(proxy)
         assert os.path.exists(token)
+
+    @pytest.mark.unit
+    def test_get_creds_default_role(self):
+        """get credentials, make sure the credentials files returned
+        exist"""
+        args = {}
+        os.environ["GROUP"] = TestUnit.test_group
+        _, _ = creds.get_creds(args)
+        assert args["role"] == "Analysis"


### PR DESCRIPTION
We were reading the role in from the default role file, but not actually setting it in a way that the template could see.  This fixes that issue.