### PR TITLE
Fix ONSITE_SITE_NAME case and make onsite --site check case-insensitive

### DIFF
--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -385,6 +385,16 @@ class TestUtilsUnit:
                     [],
                 ),
             ),
+            # --site FERMIGRID --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE (wrong case for fermigrid)
+            (
+                "FERMIGRID",
+                "",
+                ['usage_model="DEDICATED,OPPORTUNISTIC,OFFSITE"'],
+                (
+                    utils.SiteAndUsageModel("FermiGrid", "DEDICATED,OPPORTUNISTIC"),
+                    [],
+                ),
+            ),
         ]
 
         for (sites, usage_model, resource_provides_quoted, expected) in _should_work:


### PR DESCRIPTION
This fixes INC000001146876 that @hgreenlee submitted in ServiceNow.  We correct the case of `ONSITE_SITE_NAME`, and make sure that all checks for `ONSITE_SITE_NAME` in the given `--site` flag are case-insensitive checks.  This way, if someone says `--site Fermigrid` or `--site FERMIGRID`, it gets corrected.  

Also added unit test for the latter.

Passed all unit tests, as well as the following submission tests:

`jobsub_submit -G mu2e --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE --site=FermiGrid -n file:///usr/bin/printenv`
DESIRED_usage_model = "DEDICATED,OPPORTUNISTIC"
DESIRED_Sites="FermiGrid"

`jobsub_submit -G mu2e --onsite  --site=FermiGrid -n file:///usr/bin/printenv`
Not allowed - can only specify one of --site or --onsite

`jobsub_submit -G mu2e --onsite  -n file:///usr/bin/printenv`
DESIRED_usage_model = "DEDICATED,OPPORTUNISTIC"
DESIRED_Sites="FermiGrid"

`jobsub_submit -G mu2e --offsite -n file:///usr/bin/printenv`
DESIRED_usage_model = "OFFSITE"
DESIRED_Sites=""

`jobsub_submit -G mu2e --site Fermigrid -n file:///usr/bin/printenv`
DESIRED_usage_model = "DEDICATED,OPPORTUNISTIC"
DESIRED_Sites="FermiGrid"

`jobsub_submit -G mu2e --site oops  -n file:///usr/bin/printenv`
DESIRED_usage_model = "OFFSITE"
DESIRED_Sites="oops"

`jobsub_submit -G mu2e  -n file:///usr/bin/printenv`
DESIRED_usage_model = "DEDICATED,OPPORTUNISTIC,OFFSITE"
DESIRED_Sites=""