### PR TITLE
Change disk default to 10GB

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -166,7 +166,7 @@ def get_parser() -> argparse.ArgumentParser:
         " If UNITS is not specified default is 'KB' (a typo in earlier"
         " versions said that default was 'MB', this was wrong)."
         " Allowed values for UNITS are 'KB','MB','GB', and 'TB'",
-        default="35GB",
+        default="10GB",
     )
     parser.add_argument(
         "-d",


### PR DESCRIPTION
Thanks to @kherner for pointing this out.

We were using an outdated value for our default.  This was the document, which has since been updated:

https://cdcvs.fnal.gov/redmine/projects/fife/wiki/Information_about_job_submission_to_OSG_sites

