### PR TITLE
CONDOR_DIR_xxx not JOBSUB_OUT_xxx environment variable

### DIFF
--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -271,8 +271,8 @@ chmod u+x ${CONDOR_DIR_INPUT}/{{fname|basename}}
 
 # -d directories for output
 {%for pair in d%}
-export JOBSUB_OUT_{{pair[0]}}=out_{{pair[0]}}
-mkdir $JOBSUB_OUT_{{pair[0]}}
+export CONDOR_DIR_{{pair[0]}}=out_{{pair[0]}}
+mkdir $CONDOR_DIR_{{pair[0]}}
 {%endfor%}
 
 # ==========
@@ -373,7 +373,7 @@ JOB_RET_STATUS=$?
 
 # copy out -d directories
 {%for pair in d%}
-${JSB_TMP}/ifdh.sh cp -D $JOBSUB_OUT_{{pair[0]}}/* {{pair[1]}}
+${JSB_TMP}/ifdh.sh cp -D $CONDOR_DIR_{{pair[0]}}/* {{pair[1]}}
 {%endfor%}
 
 echo `date` $JOBSUB_EXE_SCRIPT COMPLETED with exit status $JOB_RET_STATUS


### PR DESCRIPTION
As in old jobsub, and the help.   Not sure where JOBSUB_OUT came from... 