### PR TITLE
use full path for decode_token.sh

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -72,7 +72,8 @@ def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
 
     # if there's a role in the wlcg.groups of the token, pick that
     if os.environ.get("BEARER_TOKEN_FILE", False):
-        with os.popen("decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
+        jldir = os.path.dirname(os.path.dirname(__file__))
+        with os.popen(f"{jldir}/bin/decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
             token_s = f.read()
             token = json.loads(token_s)
             groups: List[str] = token.get("wlcg.groups", [])
@@ -90,7 +91,8 @@ def checkToken(tokenfile: str) -> bool:
     if not os.path.exists(tokenfile):
         return False
     exp_time = None
-    cmd = f"decode_token.sh -e exp {tokenfile} 2>/dev/null"
+    jldir = os.path.dirname(os.path.dirname(__file__))
+    cmd = f"{jldir}/bin/decode_token.sh -e exp {tokenfile} 2>/dev/null"
     with os.popen(cmd, "r") as f:
         exp_time = f.read()
     try:
@@ -138,7 +140,7 @@ def getToken(role: str = DEFAULT_ROLE, verbose: int = 0) -> str:
             raise PermissionError(f"Failed attempting '{cmd}'")
         if checkToken(tokenfile):
             return tokenfile
-        raise PermissionError(f"Failed attempting '{cmd}'")
+        raise PermissionError(f"Failed validating token from '{cmd}'")
     return tokenfile
 
 

--- a/lib/token_mods.py
+++ b/lib/token_mods.py
@@ -55,7 +55,8 @@ def use_token_copy(tokenfile: str) -> str:
 def get_token_scope(tokenfilename: str) -> List[str]:
     """get the list of scopes from our token file"""
 
-    with os.popen(f"decode_token.sh -e scope {tokenfilename}", "r") as sf:
+    jldir = os.path.dirname(os.path.dirname(__file__))
+    with os.popen(f"{jldir}/bin/decode_token.sh -e scope {tokenfilename}", "r") as sf:
         data = sf.read()
         scopelist = data.strip().strip('"').split(" ")
 


### PR DESCRIPTION
This fixes the issue reported in RITM1639431, which you can reproduce by removing your bearer tokens and:
```
export PATH=/bin:/usr/bin:/usr/sbin
/opt/jobsub_lite/bin/jobsub_q 
```
which gives:
```
Attempting to get token from https://htvaultprod.fnal.gov:8200 ... succeeded
Storing bearer token in /tmp/bt_token_fermilab_Analysis_1733
decode_token.sh could not successfully extract the expiration time from token file /tmp/bt_token_fermilab_Analysis_1733. Please open a ticket to Distributed Computing Support if you need further assistance.
Traceback (most recent call last):
  File "./jobsub_q", line 228, in <module>
    main()
  File "./jobsub_q", line 152, in main
    os.environ["BEARER_TOKEN_FILE"] = fake_ifdh.getToken(role)
  File "/home/mengel/jobsub_lite/lib/fake_ifdh.py", line 139, in getToken
    if checkToken(tokenfile):
  File "/home/mengel/jobsub_lite/lib/fake_ifdh.py", line 97, in checkToken
    return int(exp_time) - time.time() > 60
ValueError: invalid literal for int() with base 10: ''
```
because it cannot find decode_token.sh.   This patch always gives the full path to the  decode_token.sh adjacent to the fake_ifdh.py module. 