### PR TITLE
add --partial argument to jobsub_fetchlog

### DIFF
--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -70,7 +70,7 @@ def main():
     parser.add_argument(
         "--partial",
         action="store_true",
-        help="download only the stdout and stderr for this jobid, not the entire sandbox",
+        help="download only the stdout, stderr, and scripts for this jobid, not the entire sandbox",
         default=False,
     )
     parser.add_argument("job_id", nargs="?", help="job/submission ID")

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -67,6 +67,12 @@ def main():
         help='format for downloaded archive: "tar" (default, compressed with gzip) or "zip"',
         default="tar",
     )
+    parser.add_argument(
+        "--partial",
+        action="store_true",
+        help="download only the stdout and stderr for this jobid, not the entire sandbox",
+        default=False,
+    )
     parser.add_argument("job_id", nargs="?", help="job/submission ID")
 
     args = parser.parse_args()
@@ -114,7 +120,7 @@ def main():
 
     # get the output sandbox
     try:
-        j.transfer_data()
+        j.transfer_data(args.partial)
         transfer_complete = True
     except htcondor.HTCondorIOError as e1:
         print(f"Error in transfer_data(): {str(e1)}")

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -307,15 +307,18 @@ class Job:
             raise Exception(f'attribute "{attr}" not found for job "{str(self)}"')
         return res[0].eval(attr)
 
-    def transfer_data(self) -> None:
+    def transfer_data(self, partial: bool = False) -> None:
         """
-        Transfer the output sandbox, akin to calling condor_transfer_data.
+        Transfer the output sandbox, akin to calling condor_transfer_data. If
+        partial is True, only fetch logs for the specified job, not the whole
+        cluster.
         """
         s = self._get_schedd()
         # always retrieve whole cluster even if we were specified with
         # a particular process id, for backwards compatability with old
         # jobsub_fetchlog
         ssc = self.cluster
-        self.cluster = True
+        if not partial:
+            self.cluster = True
         s.retrieve(self._constraint())
         self.cluster = ssc

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -315,8 +315,7 @@ class Job:
         """
         s = self._get_schedd()
         # always retrieve whole cluster even if we were specified with
-        # a particular process id, for backwards compatability with old
-        # jobsub_fetchlog
+        # a particular process id, unless partial is True
         ssc = self.cluster
         if not partial:
             self.cluster = True


### PR DESCRIPTION
We (I) inadvertently left it out of the rewrite. condor_transfer_data will abide whatever the constraint is, we were forcing it to be the cluster.