### PR TITLE
add JobsubOutputURL and JobsubUUID to dag sub files

### DIFF
--- a/templates/dag/dag.dag.condor.sub
+++ b/templates/dag/dag.dag.condor.sub
@@ -36,6 +36,8 @@ delegate_job_GSI_credentials_lifetime = 0
 
 +Jobsub_Group="{{group}}"
 +JobsubJobId="$(CLUSTER).$(PROCESS)@{{schedd}}"
++JobsubOutputURL="{{outurl}}"
++JobsubUUID="{{uuid}}"
 
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}

--- a/templates/dataset_dag/dataset.dag.condor.sub
+++ b/templates/dataset_dag/dataset.dag.condor.sub
@@ -37,6 +37,8 @@ environment	= _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address;
 
 +Jobsub_Group="{{group}}"
 +JobsubJobId="$(CLUSTER).$(PROCESS)@{{schedd}}"
++JobsubOutputURL="{{outurl}}"
++JobsubUUID="{{uuid}}"
 
 # Credentials
 {% if role is defined and role and role != 'Analysis' %}

--- a/templates/maxconcurrent_dag/maxconcurrent.dag.condor.sub
+++ b/templates/maxconcurrent_dag/maxconcurrent.dag.condor.sub
@@ -35,6 +35,8 @@ environment	= _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address;
 
 +Jobsub_Group="{{group}}"
 +JobsubJobId="$(CLUSTER).$(PROCESS)@{{schedd}}"
++JobsubOutputURL="{{outurl}}"
++JobsubUUID="{{uuid}}"
 
 # Credentials
 {% if role is defined and role and role != 'Analysis' %}


### PR DESCRIPTION
These classad attributes were inadvertently left out of the DAGs, they're needed for jobview to find the log path on dcache.