### PR TITLE
Go back to the assumption that users have decode_token.sh on their PATH.  Added bin dir to PATH for testing

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -72,8 +72,7 @@ def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
 
     # if there's a role in the wlcg.groups of the token, pick that
     if os.environ.get("BEARER_TOKEN_FILE", False):
-        jldir = os.path.dirname(os.path.dirname(__file__))
-        with os.popen(f"{jldir}/bin/decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
+        with os.popen(f"decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
             token_s = f.read()
             token = json.loads(token_s)
             groups: List[str] = token.get("wlcg.groups", [])
@@ -91,8 +90,7 @@ def checkToken(tokenfile: str) -> bool:
     if not os.path.exists(tokenfile):
         return False
     exp_time = None
-    jldir = os.path.dirname(os.path.dirname(__file__))
-    cmd = f"{jldir}/bin/decode_token.sh -e exp {tokenfile} 2>/dev/null"
+    cmd = f"decode_token.sh -e exp {tokenfile} 2>/dev/null"
     with os.popen(cmd, "r") as f:
         exp_time = f.read()
     try:

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -72,7 +72,7 @@ def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
 
     # if there's a role in the wlcg.groups of the token, pick that
     if os.environ.get("BEARER_TOKEN_FILE", False):
-        with os.popen(f"decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
+        with os.popen("decode_token.sh $BEARER_TOKEN_FILE", "r") as f:
             token_s = f.read()
             token = json.loads(token_s)
             groups: List[str] = token.get("wlcg.groups", [])

--- a/lib/token_mods.py
+++ b/lib/token_mods.py
@@ -55,8 +55,7 @@ def use_token_copy(tokenfile: str) -> str:
 def get_token_scope(tokenfilename: str) -> List[str]:
     """get the list of scopes from our token file"""
 
-    jldir = os.path.dirname(os.path.dirname(__file__))
-    with os.popen(f"{jldir}/bin/decode_token.sh -e scope {tokenfilename}", "r") as sf:
+    with os.popen(f"decode_token.sh -e scope {tokenfilename}", "r") as sf:
         data = sf.read()
         scopelist = data.strip().strip('"').split(" ")
 

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -16,8 +16,10 @@ os.chdir(os.path.dirname(__file__))
 #
 if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
     sys.path.append("/opt/jobsub_lite/lib")
+    sys.path.append("/opt/jobsub_lite/bin")
 else:
     sys.path.append("../lib")
+    sys.path.append("../bin")
 import dagnabbit
 
 from test_unit import TestUnit
@@ -140,6 +142,8 @@ class TestDagnabbitUnit:
         expected list of files"""
         varg = TestUnit.test_vargs.copy()
         dest = "/tmp/dagout{0}".format(os.getpid())
+        if os.path.exists(dest):
+            os.system("rm -rf %s" % dest)
         os.mkdir(dest)
         # the dagTest uses $SUBMIT_FLAGS so make sure we set it
         os.environ[
@@ -152,7 +156,7 @@ class TestDagnabbitUnit:
         else:
             d1 = os.path.join("..", "..", "templates", "simple")
         # file has relative paths in it, so chdir there
-        os.chdir("dagnabbit")
+        os.chdir(f"{os.path.dirname(__file__)}/dagnabbit")
         varg["dag"] = 1
         varg["executable"] = f"file://{dagfile}"
         dagnabbit.parse_dagnabbit(d1, varg, dest, TestUnit.test_schedd)

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -16,10 +16,12 @@ os.chdir(os.path.dirname(__file__))
 #
 if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
     sys.path.append("/opt/jobsub_lite/lib")
-    sys.path.append("/opt/jobsub_lite/bin")
+    _old_path = os.environ["PATH"]
+    os.environ["PATH"] = f"/opt/jobsub_lite/bin:{_old_path}"
 else:
     sys.path.append("../lib")
-    sys.path.append("../bin")
+    _old_path = os.environ["PATH"]
+    os.environ["PATH"] = f"../bin:{_old_path}"
 import dagnabbit
 
 from test_unit import TestUnit


### PR DESCRIPTION
In #280 , we broke the very esoteric use case of a python script calling jobsub_submit after doing an `os.chdir`.  So we go back to the assumption that `decode_token.sh` is in the `PATH`, and add it in for the testing case.
