### PR TITLE
Move cmd and script transfers to end of job

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -158,7 +158,12 @@ def set_extras_n_fix_units(
     if not "outurl" in args:
         args["outurl"] = ""
         if "JOBSUB_OUTPUT_URL" in os.environ:
+            # the path included in the output url needs to be included in users'
+            # tokens with storage.create scope (only!)
             base = os.environ["JOBSUB_OUTPUT_URL"]
+            # this path is sanity-checked when fetching logs, so we can't change
+            # it here without also changing the check in jobview (or whatever
+            # comes after it).
             args["outurl"] = "/".join((base, args["date"], args["uuid"]))
 
     if not "outdir" in args:

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -117,6 +117,12 @@ redirect_output_finish(){
     {% set filebase %}{{executable|basename}}{{datetime}}{{uuid}}cluster.$CLUSTER.$PROCESS{% endset %}
     IFDH_CP_MAXRETRIES=1 ${JSB_TMP}/ifdh.sh cp ${JSB_TMP}/JOBSUB_ERR_FILE.truncated {{outurl}}/{{filebase}}.err
     IFDH_CP_MAXRETRIES=1 ${JSB_TMP}/ifdh.sh cp ${JSB_TMP}/JOBSUB_LOG_FILE.truncated {{outurl}}/{{filebase}}.out
+    # copy script and jdf out to dcache sandbox
+    if [ "$PROCESS" -eq 0 ]; then
+        IFDH_CP_MAXRETRIES=0 ${JSB_TMP}/ifdh.sh cp $JOBSUB_EXE_SCRIPT {{outurl}}/{{executable|basename}}
+        {% set cmdfile %}{{cmd_name|default('simple.cmd')}}{% endset %}
+        IFDH_CP_MAXRETRIES=0 ${JSB_TMP}/ifdh.sh cp {{cmdfile}} {{outurl}}/{{cmdfile}}
+    fi
     {%endif%}
 }
 
@@ -362,15 +368,6 @@ if [ "$JOBSUB_EXE_SCRIPT" = "" ]; then
 fi
 chmod +x $JOBSUB_EXE_SCRIPT
 ${JSB_TMP}/ifdh.sh log "mengel:$JOBSUBJOBID BEGIN EXECUTION $JOBSUB_EXE_SCRIPT   {{exe_arguments|join(" ")}} "
-
-{%if outurl%}
-# copy script and jdf out to dcache sandbox
-if [ "$PROCESS" -eq 0 ]; then
-IFDH_CP_MAXRETRIES=0 ${JSB_TMP}/ifdh.sh cp $JOBSUB_EXE_SCRIPT {{outurl}}/{{executable|basename}}
-{% set cmdfile %}{{cmd_name|default('simple.cmd')}}{% endset %}
-IFDH_CP_MAXRETRIES=0 ${JSB_TMP}/ifdh.sh cp {{cmdfile}} {{outurl}}/{{cmdfile}}
-fi
-{%endif%}
 
 export NODE_NAME=`hostname`
 export BOGOMIPS=`grep bogomips /proc/cpuinfo | tail -1 | cut -d ' ' -f2`


### PR DESCRIPTION
Transfer info was showing up at the top of stderr, which could confuse and anger users. Here they won't show up in the web logs at all, but could still be seen in the spool logs for debugging. Downside is if the job is violently killed such that the postscript functions don't get to run, they won't get transferred.

Also includes a couple comments regarding changing log output url and/or path for posterity.
