### PR TITLE
Fixes to fixes

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -23,6 +23,11 @@ import sys
 import os
 import os.path
 import argparse
+
+if os.environ.get("LD_LIBRARY_PATH", ""):
+    del os.environ["LD_LIBRARY_PATH"]
+    os.execv(sys.argv[0], sys.argv)
+
 import htcondor
 
 #

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -23,6 +23,10 @@ import sys
 import os
 import os.path
 
+if os.environ.get("LD_LIBRARY_PATH", ""):
+    del os.environ["LD_LIBRARY_PATH"]
+    os.execv(sys.argv[0], sys.argv)
+
 #
 # we are in prefix/bin/jobsub_submit, so find our prefix
 #

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -23,6 +23,10 @@ import os
 import subprocess
 import shutil
 
+if os.environ.get("LD_LIBRARY_PATH", ""):
+    del os.environ["LD_LIBRARY_PATH"]
+    os.execv(sys.argv[0], sys.argv)
+
 import htcondor
 
 #

--- a/bin/jobsub_history
+++ b/bin/jobsub_history
@@ -28,6 +28,10 @@ import sys
 import re
 import time
 
+if os.environ.get("LD_LIBRARY_PATH", ""):
+    del os.environ["LD_LIBRARY_PATH"]
+    os.execv(sys.argv[0], sys.argv)
+
 PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(PREFIX, "lib"))
 

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -165,21 +165,23 @@ def submit(
         )
         sys.stdout.write(output.stdout)
 
+        hl = f"\n{'=-'*30}\n\n"  # highlight line to make result stand out
+
         if output.returncode < 0:
             sys.stderr.write(
-                f"Error: Child was terminated by signal {-output.returncode}\n"
+                f"{hl}Error: Child was terminated by signal {-output.returncode}{hl}\n"
             )
             return None
 
         if output.returncode > 0:
             sys.stderr.write(
-                f"Error: condor_submit exited with failed status code {output.returncode}\n"
+                f"{hl}Error: condor_submit exited with failed status code {output.returncode}{hl}\n"
             )
             return None
 
         m = re.search(r"\d+ job\(s\) submitted to cluster (\d+).", output.stdout)
         if m:
-            print(f"Use job id {m.group(1)}.0@{schedd_name} to retrieve output")
+            print(f"{hl}Use job id {m.group(1)}.0@{schedd_name} to retrieve output{hl}")
 
         return True
     except OSError as e:

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -70,7 +70,7 @@ def tarchmod(tfn: str) -> str:
         ti = fin.next()
         while ti:
             st = fin.extractfile(ti)
-            ti.mode = 0o755
+            ti.mode = ti.mode | 0o755
             fout.addfile(ti, st)
             ti = fin.next()
     return ofn

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -69,8 +69,12 @@ def tarchmod(tfn: str) -> str:
     with tarfile_mod.open(tfn, "r|*") as fin, tarfile_mod.open(ofn, "w|gz") as fout:
         ti = fin.next()
         while ti:
-            st = fin.extractfile(ti)
-            ti.mode = ti.mode | 0o755
+            if ti.type == tarfile_mod.SYMTYPE:
+                # dont mess with symlinks, and cannot extract them
+                st = None
+            else:
+                st = fin.extractfile(ti)
+                ti.mode = ti.mode | 0o755
             fout.addfile(ti, st)
             ti = fin.next()
     return ofn

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -49,6 +49,8 @@ class TestTarfilesUnit:
             writefile.write_text(f"This is file {i}")
         subdir_file = subdir / "test_file"
         subdir_file.write_text("This is a file in a subdirectory")
+        subdir_link = subdir / "test_link"
+        subdir_link.symlink_to(subdir_file)
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This fixes the tarball problems introduced with symlinks, adds LD_LIBRARY_PATH-proofing to rest of scripts in bin, and adds extra horizontal lines and whitespace to make the job_id  stand out.