### PR TITLE
Standardize version and support-email printing throughout code

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -36,7 +36,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 
 import fake_ifdh
 import get_parser
-import version
+from version import print_version, print_support_email
 
 
 class StoreGroupinEnvironment(argparse.Action):
@@ -67,12 +67,10 @@ def main() -> None:
     arglist, passthru = parser.parse_known_args()
 
     if arglist.version:
-        print(f"{version.__title__} version {version.__version__}")
-        exit()
+        print_version()
 
     if arglist.support_email:
-        print(f"Email {version.__email__} for help.")
-        exit()
+        print_support_email()
 
     if cmd != "jobsub_q":
         arglist.user = None

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -67,7 +67,7 @@ def main() -> None:
     arglist, passthru = parser.parse_known_args()
 
     if arglist.version:
-        print(f"jobsub_lite version {version.__version__}")
+        print(f"{version.__title__} version {version.__version__}")
         exit()
 
     if arglist.support_email:

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -43,10 +43,10 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 import creds
-import version
 from get_parser import get_jobid_parser
 from condor import Job
 from utils import cleanup
+from version import print_version, print_support_email
 
 
 def main():
@@ -82,12 +82,10 @@ def main():
     args = parser.parse_args()
 
     if args.version:
-        print(f"{version.__title__} version {version.__version__}")
-        exit()
+        print_version()
 
     if args.support_email:
-        print(f"Email {version.__email__} for help.")
-        exit()
+        print_support_email()
 
     if not args.jobid and not args.job_id:
         raise SystemExit("jobid is required.")

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -82,7 +82,7 @@ def main():
     args = parser.parse_args()
 
     if args.version:
-        print(f"jobsub_lite version {version.__version__}")
+        print(f"{version.__title__} version {version.__version__}")
         exit()
 
     if args.support_email:

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -191,7 +191,7 @@ def main():
         ]
 
     if args.version:
-        print(f"jobsub_lite version {version.__version__}")
+        print(f"{version.__title__} version {version.__version__}")
         exit()
 
     if args.support_email:

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -56,7 +56,7 @@ from tarfiles import do_tarballs
 from utils import set_extras_n_fix_units, cleanup, backslash_escape_layer
 from creds import get_creds
 from token_mods import get_job_scopes, use_token_copy
-import version
+from version import print_version, print_support_email
 
 
 def get_basefiles(dlist: List[str]) -> List[str]:
@@ -191,12 +191,10 @@ def main():
         ]
 
     if args.version:
-        print(f"{version.__title__} version {version.__version__}")
-        exit()
+        print_version()
 
     if args.support_email:
-        print(f"Email {version.__email__} for help.")
-        exit()
+        print_support_email()
 
     # We want to push users to use jobsub_submit --dag, but there are still some legacy
     # users who use the old jobsub_submit_dag executable.  This patches that use case

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -27,6 +27,8 @@ import shutil
 import time
 from typing import Union, Dict, Any, NamedTuple, Tuple, List
 
+import version
+
 ONSITE_SITE_NAME = "FermiGrid"
 DEFAULT_USAGE_MODELS = ["DEDICATED", "OPPORTUNISTIC", "OFFSITE"]
 
@@ -116,7 +118,7 @@ def set_extras_n_fix_units(
         args["ipaddr"] = "unknown"
     args["proxy"] = proxy
     args["token"] = token
-    args["jobsub_version"] = "lite_v1_0"
+    args["jobsub_version"] = f"{version.__title__}-v{version.__version__}"
     args["kerberos_principal"] = get_principal()
     args["uid"] = str(os.getuid())
 

--- a/lib/version.py
+++ b/lib/version.py
@@ -24,3 +24,13 @@ __email__ = "jobsub-support@fnal.gov"
 __license__ = "Apache License, Version 2.0"
 __author__ = "Fermi National Accelerator Laboratory"
 __copyright__ = "2023 %s" % __author__
+
+
+def print_version() -> None:
+    print(f"{__title__} version {__version__}")
+    exit()
+
+
+def print_support_email() -> None:
+    print(f"Email {__email__} for help.")
+    exit()


### PR DESCRIPTION
Closes #306 

We had different places setting the version, and we want as few of these as possible.  So now, the `lib/version.py` controls the version given throughout the library, and how it's printed.  This version variable is also printed in the templates, but with a slightly different form, as discussed in #306.  

So when the jobsub commands print the version, it looks like:
`jobsub_lite version 1.1.1`

And in the job templates, it looks like:
`JobsubClientVersion="jobsub_lite-v1.1.1"`

Note:  If approved, *DO NOT MERGE* until after 1.1.2 is deployed, on 2023-03-01.
