### PR TITLE
dagman crunching patch for values ending up in the shell script

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -130,9 +130,16 @@ def set_extras_n_fix_units(
         sys.stderr.write(
             f"checking args[executable]: {repr(args.get('executable', None))}\n"
         )
+
     if not args["executable"] and args["exe_arguments"]:
         args["executable"] = args["exe_arguments"][-1]
         args["exe_arguments"] = args["exe_arguments"][:-1]
+
+    # fixup collapsed DAG arguments.
+    args["exe_arguments"] = [
+        x.replace("$(CM1)", "${CM1}").replace("$(CM2)", "${CM2}")
+        for x in args["exe_arguments"]
+    ]
 
     if args["executable"]:
         args["full_executable"] = args["executable"]

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -13,7 +13,7 @@ log                = {{filebase}}.log
 JOBSUBJOBSECTION=$(Process)
 {%endif%}
 
-environment        = CLUSTER=$(Cluster);PROCESS=$(Process);JOBSUBJOBSECTION=$(JOBSUBJOBSECTION);CONDOR_TMP={{outdir}};BEARER_TOKEN_FILE=.condor_creds/{{group}}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
+environment        = CM1=$(CM1);CM2=$(CM2);CLUSTER=$(Cluster);PROCESS=$(Process);JOBSUBJOBSECTION=$(JOBSUBJOBSECTION);CONDOR_TMP={{outdir}};BEARER_TOKEN_FILE=.condor_creds/{{group}}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
 rank               = Mips / 2 + Memory
 job_lease_duration = 3600
 notification       = Never

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -127,6 +127,9 @@ class TestDagnabbitUnit:
                 "dag.dag": "JOB stage_3 stage_2.cmd",
                 "dag.dag": "JOB stage_4 stage_2.cmd",
                 "dag.dag": "JOB stage_11 stage_2.cmd",
+                # and our cmd should use $(CM2) but the sh should use ${CM2}
+                "stage_2.sh": r"\$\{CM2\}",
+                "stage_2.cmd": r"\$\(CM2\)",
             },
             [
                 # we should NOT have scripts/cmd files for stages 3..11


### PR DESCRIPTION
Yet another patch on the DAG-crunching, for when the count gets passed through into the wrapper script on the command arguments; where we need to convert the DAG/submit parameters to environment variables to use them.