### PR TITLE
added -d tag dir test and check in integration tests

### DIFF
--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -281,7 +281,7 @@ chmod u+x ${CONDOR_DIR_INPUT}/{{fname|basename}}
 
 # -d directories for output
 {%for pair in d%}
-export CONDOR_DIR_{{pair[0]}}=out_{{pair[0]}}
+export CONDOR_DIR_{{pair[0]}}=`pwd`/out_{{pair[0]}}
 mkdir $CONDOR_DIR_{{pair[0]}}
 {%endfor%}
 

--- a/tests/job_scripts/lookaround.sh
+++ b/tests/job_scripts/lookaround.sh
@@ -57,3 +57,12 @@ do
        exit 1
    fi
 done
+
+# put something in any -d TAG /return/path areas for testing
+outdirs=`printenv | grep '^CONDOR_DIR_' | sed -e 's/=.*//'`
+echo "=== out dirs: $outdirs ==="
+for od in $outdirs
+do
+   eval "echo $od = \$$od"
+   eval "echo test $od > \$$od/testout.txt"
+done

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -429,6 +429,11 @@ def test_fetch_output():
 
 @pytest.mark.integration
 def test_check_job_output():
+    for jid, ddir in ddirs.items():
+        print(f"Checking {jid2test[jid]} {jid} -d tag  {ddir}...")
+        fl = fake_ifdh.ls(ddir)
+        assert len(fl)
+
     for jid, outdir in outdirs.items():
         fl = glob.glob("%s/*.log" % outdir)
         for f in fl:
@@ -442,8 +447,3 @@ def test_check_job_output():
             fd.close()
             assert f_ok
         shutil.rmtree(outdir)
-
-    for jid, ddir in ddirs.items():
-        print(f"Checking {jid2test[jid]} {jid} -d tag  {ddir}...")
-        fl = fake_ifdh.ls(ddir)
-        assert len(fl)

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -130,6 +130,7 @@ def dune_gp(dune):
 joblist = []
 jid2test = {}
 outdirs = {}
+ddirs = {}
 
 
 def run_launch(cmd):
@@ -189,6 +190,15 @@ def lookaround_launch(extra, verify_files=""):
 @pytest.mark.integration
 def test_launch_lookaround_samdev(samdev):
     lookaround_launch("--devserver")
+
+
+@pytest.mark.integration
+def test_launch_lookaround_ddir(samdev):
+    pid = os.getpid()
+    ddir = f"/pnfs/fermilab/users/$USER/d{pid}"
+    fake_ifdh.mkdir_p(ddir)
+    lookaround_launch(f"--devserver -d D1 {ddir}")
+    ddirs[joblist[-1]] = ddir
 
 
 @pytest.mark.integration
@@ -432,3 +442,8 @@ def test_check_job_output():
             fd.close()
             assert f_ok
         shutil.rmtree(outdir)
+
+    for jid, ddir in ddirs.items():
+        print(f"Checking {jid2test[jid]} {jid} -d tag  {ddir}...")
+        fl = fake_ifdh.ls(ddir)
+        assert len(fl)


### PR DESCRIPTION
add  pwd bits to template for CONDOR_OUT_BLAH  environment variables.

Add -d BLAH dir test to the test suite, and make sure lookaround.sh puts a file there and verify it gets copied out. 