### PR TITLE
Tarfile dag

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -210,6 +210,8 @@ def main():
     # Eventually, this arg and its support in the underlying libraries should be removed
     args.force_proxy = True
 
+    do_tarballs(args)
+
     varg = vars(args)
 
     proxy, token = get_creds(varg)
@@ -218,10 +220,8 @@ def main():
         print(f"proxy is : {proxy}")
         print(f"token is : {token}")
 
-    if args.debug:
+    if args.verbose:
         sys.stderr.write(f"varg: {repr(varg)}\n")
-
-    do_tarballs(args)
 
     schedd_add = get_schedd(varg)
     schedd_name = schedd_add.eval("Machine")

--- a/lib/dagnabbit.py
+++ b/lib/dagnabbit.py
@@ -192,6 +192,11 @@ def parse_dagnabbit(
                         if update_with[k] is parser.get_default(k):
                             del update_with[k]
 
+                    # the list ones here do  not get cleaned out by the above
+                    for k in ["input_file", "tar_file_name", "tar_file_orig_basenames"]:
+                        if not update_with[k]:
+                            del update_with[k]
+
                     thesevalues.update(update_with)
                     set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
                     thesevalues["script_name"] = f"{name}.sh"

--- a/lib/dagnabbit.py
+++ b/lib/dagnabbit.py
@@ -200,7 +200,9 @@ def parse_dagnabbit(
                     # do not just update, rather update but also merge items that are lists
                     for k in update_with:
                         if isinstance(thesevalues.get(k, False), List):
-                            thesevalues[k].extend(update_with[k])
+                            # note this has to be a list plus, if you do thesevalues[k].extend(update_with[k]) you
+                            # keep expanding the original list and the values pile up
+                            thesevalues[k] = thesevalues[k] + update_with[k]
                         else:
                             thesevalues[k] = update_with[k]
 

--- a/lib/dagnabbit.py
+++ b/lib/dagnabbit.py
@@ -141,8 +141,8 @@ def parse_dagnabbit(
                 # (which we will pass in as a dag # job parameter)
                 # to assist compaction...
                 # ONLY do the very end
-                line = re.sub(f"\\b{count-2}\s*$", "$(CM2)", line)
-                line = re.sub(f"\\b{count-1}\s*$", "$(CM1)", line)
+                line = re.sub(f"\\b{count-2}\\s*$", "$(CM2)", line)
+                line = re.sub(f"\\b{count-1}\\s*$", "$(CM1)", line)
 
                 if line == prev_jobsub_line:
 
@@ -197,7 +197,13 @@ def parse_dagnabbit(
                         if not update_with[k]:
                             del update_with[k]
 
-                    thesevalues.update(update_with)
+                    # do not just update, rather update but also merge items that are lists
+                    for k in update_with:
+                        if isinstance(thesevalues.get(k, False), List):
+                            thesevalues[k].extend(update_with[k])
+                        else:
+                            thesevalues[k] = update_with[k]
+
                     set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
                     thesevalues["script_name"] = f"{name}.sh"
                     thesevalues["cmd_name"] = f"{name}.cmd"

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -73,10 +73,9 @@ def check_we_can_write() -> None:
 
 def tarchmod(tfn: str) -> str:
     """copy a tarfile to a compressed tarfile changing modes of contents to 755"""
-    os.environ["GZIP"] = "-n"
-    ofn = os.path.basename(f"{tfn}.o.gz")
+    ofn = os.path.basename(f"{tfn}.o.bz2")
     check_we_can_write()
-    with tarfile_mod.open(tfn, "r|*") as fin, tarfile_mod.open(ofn, "w|gz") as fout:
+    with tarfile_mod.open(tfn, "r|*") as fin, tarfile_mod.open(ofn, "w|bz2") as fout:
         ti = fin.next()
         while ti:
             if ti.type in (tarfile_mod.SYMTYPE, tarfile_mod.LNKTYPE):

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -73,7 +73,7 @@ def check_we_can_write() -> None:
 
 def tarchmod(tfn: str) -> str:
     """copy a tarfile to a compressed tarfile changing modes of contents to 755"""
-    ofn = os.path.basename(f"{tfn}.o.bz2")
+    ofn = os.path.basename(f"{tfn}.tbz2")
     check_we_can_write()
     with tarfile_mod.open(tfn, "r|*") as fin, tarfile_mod.open(ofn, "w|bz2") as fout:
         ti = fin.next()
@@ -93,7 +93,7 @@ def tar_up(directory: str, excludes: str, file: str = ".") -> str:
     """build directory.tar from path/to/directory"""
     if not directory:
         directory = "."
-    tarfile = os.path.basename(f"{directory}.tar.gz")
+    tarfile = os.path.basename(f"{directory}.tgz")
     check_we_can_write()
     if not excludes:
         excludes = os.path.dirname(__file__) + "/../etc/excludes"
@@ -211,7 +211,10 @@ def do_tarballs(args: argparse.Namespace) -> None:
     orig_basenames = []
     for tfn in args.tar_file_name:
         orig_basenames.append(
-            os.path.basename(tfn).replace(".tar", "").replace(".tgz", "")
+            os.path.basename(tfn)
+            .replace(".tbz2", "")
+            .replace(".tar", "")
+            .replace(".tgz", "")
         )
 
         if tfn.startswith("tardir://"):

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -262,7 +262,7 @@ chmod u+x ${CONDOR_DIR_INPUT}/{{fname|basename}}
     mkdir .unwind_{{loop.index0}}
     {%set tflocal = '.unwind_%d/%s' % (loop.index0, tfname|basename) %}
     ${JSB_TMP}/ifdh.sh cp {{tfname}} {{tflocal}}
-    tar --directory .unwind_{{loop.index0}} -xzvf {{tflocal}}
+    tar --directory .unwind_{{loop.index0}} -xjvf {{tflocal}}
     {%if loop.first%}
       INPUT_TAR_DIR_LOCAL=`pwd`/.unwind_{{loop.index0}}
       export INPUT_TAR_DIR_LOCAL

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -75,15 +75,15 @@ class TestDagnabbitUnit:
                 "stage_5.cmd",
             ],
             {
-                "stage_1.cmd": r"environment\s*= .*foo=bar;baz=bleem.*",
-                "stage_5.cmd": r"environment\s*= .*foo=bar;baz=bleem.*",
+                "stage_1.cmd": r"environment\s*= .*baz=bleem;foo=bar.*",
+                "stage_5.cmd": r"environment\s*= .*baz=bleem;foo=bar.*",
             },
             submit_flags="-e foo=bar",
             varg_update={"environment": ["baz=bleem"]},
         )
 
     @pytest.mark.unit
-    def test_parse_dagnabbit_merge(self):
+    def test_parse_dagnabbit_merge_tar(self):
         """make sure -tar-file-name values from command line/varg and dagnabbit file get merged"""
         self.do_one_dagnabbit(
             "dagTest",
@@ -102,9 +102,9 @@ class TestDagnabbitUnit:
             ],
             {
                 "stage_1.sh": r"ifdh.sh cp /a/b/c",
-                "stage_1.sh": r"ifdh.sh cp /d/e/f",
+                "./stage_1.sh": r"ifdh.sh cp /d/e/f",
                 "stage_5.sh": r"ifdh.sh cp /a/b/c",
-                "stage_5.sh": r"ifdh.sh cp /d/e/f",
+                "./stage_5.sh": r"ifdh.sh cp /d/e/f",
             },
             submit_flags="--tar-file-name /a/b/c",
             varg_update={"tar_file_name": ["/d/e/f"]},

--- a/tests/test_dagnabbit_unit.py
+++ b/tests/test_dagnabbit_unit.py
@@ -57,6 +57,60 @@ class TestDagnabbitUnit:
         )
 
     @pytest.mark.unit
+    def test_parse_dagnabbit_merge(self):
+        """make sure -e values from command line/varg and dagnabbit file get merged"""
+        self.do_one_dagnabbit(
+            "dagTest",
+            [
+                "dag.dag",
+                "stage_1.sh",
+                "stage_2.sh",
+                "stage_3.sh",
+                "stage_4.sh",
+                "stage_5.sh",
+                "stage_1.cmd",
+                "stage_2.cmd",
+                "stage_3.cmd",
+                "stage_4.cmd",
+                "stage_5.cmd",
+            ],
+            {
+                "stage_1.cmd": r"environment\s*= .*foo=bar;baz=bleem.*",
+                "stage_5.cmd": r"environment\s*= .*foo=bar;baz=bleem.*",
+            },
+            submit_flags="-e foo=bar",
+            varg_update={"environment": ["baz=bleem"]},
+        )
+
+    @pytest.mark.unit
+    def test_parse_dagnabbit_merge(self):
+        """make sure -tar-file-name values from command line/varg and dagnabbit file get merged"""
+        self.do_one_dagnabbit(
+            "dagTest",
+            [
+                "dag.dag",
+                "stage_1.sh",
+                "stage_2.sh",
+                "stage_3.sh",
+                "stage_4.sh",
+                "stage_5.sh",
+                "stage_1.cmd",
+                "stage_2.cmd",
+                "stage_3.cmd",
+                "stage_4.cmd",
+                "stage_5.cmd",
+            ],
+            {
+                "stage_1.sh": r"ifdh.sh cp /a/b/c",
+                "stage_1.sh": r"ifdh.sh cp /d/e/f",
+                "stage_5.sh": r"ifdh.sh cp /a/b/c",
+                "stage_5.sh": r"ifdh.sh cp /d/e/f",
+            },
+            submit_flags="--tar-file-name /a/b/c",
+            varg_update={"tar_file_name": ["/d/e/f"]},
+        )
+
+    @pytest.mark.unit
     def test_parse_dagnabbit_dagTest6(self):
         """test dagnabbit parser on old jobsub dagTest example"""
         self.do_one_dagnabbit(
@@ -142,18 +196,25 @@ class TestDagnabbitUnit:
             ],
         )
 
-    def do_one_dagnabbit(self, dagfile, flist, check4={}, fnotlist=[]):
+    def do_one_dagnabbit(
+        self, dagfile, flist, check4={}, fnotlist=[], submit_flags="", varg_update=None
+    ):
         """test dagnabbit parser on given dagfile make sure it generates
         expected list of files"""
         varg = TestUnit.test_vargs.copy()
+        if varg_update:
+            varg.update(varg_update)
         dest = "/tmp/dagout{0}".format(os.getpid())
         if os.path.exists(dest):
             os.system("rm -rf %s" % dest)
         os.mkdir(dest)
         # the dagTest uses $SUBMIT_FLAGS so make sure we set it
-        os.environ[
-            "SUBMIT_FLAGS"
-        ] = "--resource-provides=usage_model=DEDICATED,OPPORTUNISTIC"
+        if submit_flags:
+            os.environ["SUBMIT_FLAGS"] = submit_flags
+        else:
+            os.environ[
+                "SUBMIT_FLAGS"
+            ] = "--resource-provides=usage_model=DEDICATED,OPPORTUNISTIC"
         os.environ["JOBSUB_EXPORTS"] = "--mail-on-error"
         os.environ["GROUP"] = TestUnit.test_group
         if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":


### PR DESCRIPTION
This addresses an issue Vito brought up, in #320, but also rubbed my nose in the fact that we weren't doing combinations of, say -e arguments on the command line versus the dagnabbit file properly -- if the dagnabbit file specified -e anything, that overrode *all* -e arguments from the command line, etc. when we should merge them.

Also switched the tarfile regeneration to make .bz2 files rather than .gz ones, as we had the random-hash due to current time showing up in those .gz tarballs, even with GZIP=-n set in the environment.  Now we get consistent hashes for tarfiles again.