### PR TITLE
Resolve --singularity-image and --lines with +SingularityImage conflicts

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -21,7 +21,7 @@ import re
 import sys
 from typing import Union, Any
 
-from utils import DEFAULT_USAGE_MODELS
+from utils import DEFAULT_USAGE_MODELS, DEFAULT_SINGULARITY_IMAGE
 
 
 def verify_executable_starts_with_file_colon(s: str) -> str:
@@ -466,7 +466,7 @@ def get_parser() -> argparse.ArgumentParser:
     singularity_group.add_argument(
         "--singularity-image",
         "--apptainer-image",
-        default="/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        default=DEFAULT_SINGULARITY_IMAGE,
         help="Singularity image to run jobs in.  Default is "
         "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
     )

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -240,6 +240,17 @@ def set_extras_n_fix_units(
             args["singularity_image"], args["lines"] = _resolve_singularity_image(
                 args.get("singularity_image", DEFAULT_SINGULARITY_IMAGE), args["lines"]
             )
+        else:
+            # Strip out any line with "SingularityImage=" in it, since --no-singularity is specified
+            _lines = [line for line in args["lines"] if "SingularityImage=" not in line]
+            if len(_lines) != args["lines"]:
+                print(
+                    "Warning:  --lines contains a SingularityImage specification "
+                    "but --no-singularity was also passed on command line. "
+                    "jobsub_lite will remove the --lines parameter that contains "
+                    "SingularityImage."
+                )
+            args["lines"] = _lines
 
     #
     # allow short, medium, and long for duration values (--expected_lifetime, --timeout)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -20,7 +20,6 @@ import os
 import os.path
 import re
 import socket
-import shlex
 import subprocess
 import sys
 import uuid

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -20,17 +20,21 @@ import os
 import os.path
 import re
 import socket
-import sys
+import shlex
 import subprocess
+import sys
 import uuid
 import shutil
 import time
-from typing import Union, Dict, Any, NamedTuple, Tuple, List
+from typing import Union, Dict, Any, NamedTuple, Tuple, List, Optional
 
 import version
 
 ONSITE_SITE_NAME = "FermiGrid"
 DEFAULT_USAGE_MODELS = ["DEDICATED", "OPPORTUNISTIC", "OFFSITE"]
+DEFAULT_SINGULARITY_IMAGE = (
+    "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+)
 
 
 def cleandir(d: str) -> None:
@@ -231,6 +235,12 @@ def set_extras_n_fix_units(
     # in, so guard against those kinds of things
     if args.get("lines"):
         args["lines"] = [line for line in args["lines"] if line not in ('""', "''")]
+        # Check --lines for SingularityImage, resolve the possible case where that AND --singularity-image
+        # are specified, as long as --no-singularity is not set
+        if not args.get("no_singularity", False):
+            args["singularity_image"], args["lines"] = _resolve_singularity_image(
+                args.get("singularity_image", DEFAULT_SINGULARITY_IMAGE), args["lines"]
+            )
 
     #
     # allow short, medium, and long for duration values (--expected_lifetime, --timeout)
@@ -565,3 +575,57 @@ class SiteAndUsageModelConflictError(Exception):
             f"a site list that does not include {ONSITE_SITE_NAME}."
         )
         super().__init__(self.message)
+
+
+def _resolve_singularity_image(
+    singularity_image_from_args: str, lines: List[str]
+) -> Tuple[str, List[str]]:
+    """
+    Determine what the proper --singularity-image flag should be, parsing both that flag and the --lines
+    arguments.  If --lines has a SingularityImage flag specified, we should remove that from --lines and
+    put it in the return value of singularity_image.
+
+    Order of precedence:
+    1. Non-default singularity-image argument
+    2. --lines SingularityImage argument
+    3. Default singularity-image argument
+
+    Returns a tuple of (singularity_image, lines (modified or not))
+    """
+    lines_singularity_re = re.compile(".+SingularityImage\=(.+)")
+    lines_singularity_image: Optional[str] = None
+    return_lines: List[str] = []
+
+    # Parse lines.
+    # Look for something like:
+    #     '+SingularityImage=\\\"/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest\\\"'
+    # in lines and remove it while setting lines_singularity_image
+    # In the above example, if there were such a line, lines_singularity_image would be set to
+    # "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+    for line in lines:
+        m = lines_singularity_re.match(line)
+        if m:
+            raw_singularity_image = m.group(1)
+            # Since most of the time the SingularityImage here is heavily-escaped, we need to strip out all double-quotes and backslashes
+            lines_singularity_image = raw_singularity_image.strip('"\\')
+            msg = (
+                f"Warning: SingularityImage {lines_singularity_image} specified in "
+                "--lines.  A non-default --singularity-image value takes precedence, "
+                "but a non-default SingularityImage may be specified here for backward-compatibility. "
+                "--lines SingularityImage ONLY takes precedence over --singularity-image if "
+                "--singularity-image value is not the default and --no-singularity is not given "
+                "on the command line."
+            )
+            print(msg)
+        else:
+            return_lines.append(line)
+
+    # If we have a non-default --singularity-image given on the command line, use that
+    if singularity_image_from_args != DEFAULT_SINGULARITY_IMAGE:
+        return (singularity_image_from_args, return_lines)
+
+    # If SingularityImage is specified in lines, use that
+    if lines_singularity_image:
+        return (lines_singularity_image, return_lines)
+
+    return (DEFAULT_SINGULARITY_IMAGE, return_lines)

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import os
 import sys
 import tempfile
@@ -171,23 +172,27 @@ class TestUtilsUnit:
 
     @pytest.mark.unit
     def test_resolve_site_and_usage_model(self):
+        TestCase = namedtuple(
+            "TestCase",
+            ["sites", "usage_model", "resource_provides_quoted", "expected_result"],
+        )
         _should_work = [
             # no flags
-            (
-                "",
-                "DEDICATED,OPPORTUNISTIC,OFFSITE",
-                [],
-                (
+            TestCase(
+                sites="",
+                usage_model="DEDICATED,OPPORTUNISTIC,OFFSITE",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel("", "DEDICATED,OPPORTUNISTIC,OFFSITE"),
                     [],
                 ),
             ),
             # --onsite
-            (
-                "",
-                "DEDICATED,OPPORTUNISTIC",
-                [],
-                (
+            TestCase(
+                sites="",
+                usage_model="DEDICATED,OPPORTUNISTIC",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -195,11 +200,11 @@ class TestUtilsUnit:
                 ),
             ),
             # --site Fermigrid
-            (
-                utils.ONSITE_SITE_NAME,
-                "",
-                [],
-                (
+            TestCase(
+                sites=utils.ONSITE_SITE_NAME,
+                usage_model="",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -207,41 +212,41 @@ class TestUtilsUnit:
                 ),
             ),
             # --site Random_Site
-            (
-                "Random_Site",
-                "",
-                [],
-                (
+            TestCase(
+                sites="Random_Site",
+                usage_model="",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
                 ),
             ),
             # --offsite
-            (
-                "",
-                "OFFSITE",
-                [],
-                (
+            TestCase(
+                sites="",
+                usage_model="OFFSITE",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel("", "OFFSITE"),
                     [],
                 ),
             ),
             # --resource-provides=usage_model=DEDICATED,OFFSITE
-            (
-                "",
-                "",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites="",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel("", ""),
                     ['usage_model="DEDICATED,OFFSITE"'],
                 ),
             ),
             # --resource-provides=usage_model=DEDICATED,OFFSITE --site Fermigrid
-            (
-                utils.ONSITE_SITE_NAME,
-                "",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites=utils.ONSITE_SITE_NAME,
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -249,21 +254,21 @@ class TestUtilsUnit:
                 ),
             ),
             # --resource-provides=usage_model=DEDICATED,OFFSITE --site Random_Site
-            (
-                "Random_Site",
-                "",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites="Random_Site",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
                 ),
             ),
             # --site=Fermigrid,Random_Site --resource-provides=usage_model=DEDICATED,OFFSITE
-            (
-                f"{utils.ONSITE_SITE_NAME},Random_Site",
-                "",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites=f"{utils.ONSITE_SITE_NAME},Random_Site",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         f"{utils.ONSITE_SITE_NAME},Random_Site",
                         "DEDICATED,OPPORTUNISTIC,OFFSITE",
@@ -272,11 +277,11 @@ class TestUtilsUnit:
                 ),
             ),
             # --site=Fermigrid,Random_Site
-            (
-                f"{utils.ONSITE_SITE_NAME},Random_Site",
-                "",
-                [],
-                (
+            TestCase(
+                sites=f"{utils.ONSITE_SITE_NAME},Random_Site",
+                usage_model="",
+                resource_provides_quoted=[],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         f"{utils.ONSITE_SITE_NAME},Random_Site",
                         "DEDICATED,OPPORTUNISTIC,OFFSITE",
@@ -285,11 +290,14 @@ class TestUtilsUnit:
                 ),
             ),
             # --site=Fermigrid,Random_Site --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource
-            (
-                f"{utils.ONSITE_SITE_NAME},Random_Site",
-                "",
-                ['usage_model="DEDICATED,OFFSITE"', 'IWANT="this_resource"'],
-                (
+            TestCase(
+                sites=f"{utils.ONSITE_SITE_NAME},Random_Site",
+                usage_model="",
+                resource_provides_quoted=[
+                    'usage_model="DEDICATED,OFFSITE"',
+                    'IWANT="this_resource"',
+                ],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         f"{utils.ONSITE_SITE_NAME},Random_Site",
                         "DEDICATED,OPPORTUNISTIC,OFFSITE",
@@ -298,11 +306,14 @@ class TestUtilsUnit:
                 ),
             ),
             # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource
-            (
-                "",
-                "DEDICATED,OPPORTUNISTIC",
-                ['usage_model="DEDICATED,OFFSITE"', 'IWANT="this_resource"'],
-                (
+            TestCase(
+                sites="",
+                usage_model="DEDICATED,OPPORTUNISTIC",
+                resource_provides_quoted=[
+                    'usage_model="DEDICATED,OFFSITE"',
+                    'IWANT="this_resource"',
+                ],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -310,11 +321,11 @@ class TestUtilsUnit:
                 ),
             ),
             # --onsite --resource_provides=usage_model=DEDICATED,OFFSITE
-            (
-                "",
-                "DEDICATED,OPPORTUNISTIC",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites="",
+                usage_model="DEDICATED,OPPORTUNISTIC",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -322,31 +333,31 @@ class TestUtilsUnit:
                 ),
             ),
             # --resource_provides=usage_model=DEDICATED,OPPORTUNISTIC --site Random_Site
-            (
-                "Random_Site",
-                "",
-                ['usage_model="DEDICATED,OPPORTUNISTIC"'],
-                (
+            TestCase(
+                sites="Random_Site",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OPPORTUNISTIC"'],
+                expected_result=(
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
                 ),
             ),
             # --resource-provides=usage_model=DEDICATED --site Random_Site
-            (
-                "Random_Site",
-                "",
-                ['usage_model="DEDICATED"'],
-                (
+            TestCase(
+                sites="Random_Site",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED"'],
+                expected_result=(
                     utils.SiteAndUsageModel("Random_Site", "OFFSITE"),
                     [],
                 ),
             ),
             # --resource-provides=usage_model=OFFSITE --site Fermigrid
-            (
-                utils.ONSITE_SITE_NAME,
-                "",
-                ['usage_model="OFFSITE"'],
-                (
+            TestCase(
+                sites=utils.ONSITE_SITE_NAME,
+                usage_model="",
+                resource_provides_quoted=['usage_model="OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -354,21 +365,21 @@ class TestUtilsUnit:
                 ),
             ),
             # --site=Random_Site_1,Random_Site_2 --resource-provides=usage_model=DEDICATED,OFFSITE
-            (
-                "Random_Site_1,Random_Site_2",
-                "",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites="Random_Site_1,Random_Site_2",
+                usage_model="",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel("Random_Site_1,Random_Site_2", "OFFSITE"),
                     [],
                 ),
             ),
             # --onsite --resource-provides=usage_model=DEDICATED,OFFSITE
-            (
-                "",
-                "DEDICATED,OPPORTUNISTIC",
-                ['usage_model="DEDICATED,OFFSITE"'],
-                (
+            TestCase(
+                sites="",
+                usage_model="DEDICATED,OPPORTUNISTIC",
+                resource_provides_quoted=['usage_model="DEDICATED,OFFSITE"'],
+                expected_result=(
                     utils.SiteAndUsageModel(
                         utils.ONSITE_SITE_NAME, "DEDICATED,OPPORTUNISTIC"
                     ),
@@ -376,33 +387,37 @@ class TestUtilsUnit:
                 ),
             ),
             # --offsite --resource-provides=usage_model=DEDICATED
-            (
-                "",
-                "OFFSITE",
-                ['usage_model="DEDICATED"'],
-                (
+            TestCase(
+                sites="",
+                usage_model="OFFSITE",
+                resource_provides_quoted=['usage_model="DEDICATED"'],
+                expected_result=(
                     utils.SiteAndUsageModel("", "OFFSITE"),
                     [],
                 ),
             ),
             # --site FERMIGRID --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE (wrong case for fermigrid)
-            (
-                "FERMIGRID",
-                "",
-                ['usage_model="DEDICATED,OPPORTUNISTIC,OFFSITE"'],
-                (
+            TestCase(
+                sites="FERMIGRID",
+                usage_model="",
+                resource_provides_quoted=[
+                    'usage_model="DEDICATED,OPPORTUNISTIC,OFFSITE"'
+                ],
+                expected_result=(
                     utils.SiteAndUsageModel("FermiGrid", "DEDICATED,OPPORTUNISTIC"),
                     [],
                 ),
             ),
         ]
 
-        for (sites, usage_model, resource_provides_quoted, expected) in _should_work:
+        for test_case in _should_work:
             assert (
                 utils.resolve_site_and_usage_model(
-                    sites, usage_model, resource_provides_quoted
+                    test_case.sites,
+                    test_case.usage_model,
+                    test_case.resource_provides_quoted,
                 )
-                == expected
+                == test_case.expected_result
             )
 
         # I honestly can't think of any combos that don't work/won't get corrected before we get to validation,
@@ -415,3 +430,69 @@ class TestUtilsUnit:
                 utils.resolve_site_and_usage_model(
                     sites, usage_model, resource_provides_quoted
                 )
+
+    @pytest.mark.unit
+    def test_resolve_singularity_image(self):
+        non_default_singularity_image = (
+            "/cvmfs/singularity.opensciencegrid.org/fake/image:latest"
+        )
+        non_default_singularity_image_lines = (
+            "/cvmfs/singularity.opensciencegrid.org/fake/image:latest_lines"
+        )
+        lines_with_singularity = [
+            "key1=value1",
+            "key2=value2",
+            f'+SingularityImage=\\"{non_default_singularity_image_lines}\\"',
+            "key3=value3",
+        ]
+        lines_without_singularity = [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3",
+        ]
+        TestCase = namedtuple(
+            "TestCase",
+            [
+                "singularity_image_arg",
+                "lines_arg",
+                "expected_singularity_image",
+                "expected_lines",
+            ],
+        )
+        _test_cases = (
+            # --singularity_image=DEFAULT_SINGULARITY_IMAGE, --lines does not have SingularityImage:  DEFAULT_SINGULARITY_IMAGE, lines=old lines
+            TestCase(
+                singularity_image_arg=utils.DEFAULT_SINGULARITY_IMAGE,
+                lines_arg=lines_without_singularity,
+                expected_singularity_image=utils.DEFAULT_SINGULARITY_IMAGE,
+                expected_lines=lines_without_singularity,
+            ),
+            # --singularity_image=DEFAULT_SINGULARITY_IMAGE, --lines has non-default SingularityImage:  non-default lines-Singularity_image, lines modified
+            TestCase(
+                singularity_image_arg=utils.DEFAULT_SINGULARITY_IMAGE,
+                lines_arg=lines_with_singularity,
+                expected_singularity_image=non_default_singularity_image_lines,
+                expected_lines=lines_without_singularity,
+            ),
+            # --singularity_image=non-default-image, --lines does not have SingularityImage: non-default singularity_image from arg, lines=old lines
+            TestCase(
+                singularity_image_arg=non_default_singularity_image,
+                lines_arg=lines_without_singularity,
+                expected_singularity_image=non_default_singularity_image,
+                expected_lines=lines_without_singularity,
+            ),
+            # --singularity_image=non-default-image, --lines has non-default SingularityImage: non-default singularity_image from arg, lines modified (and ignored)
+            TestCase(
+                singularity_image_arg=non_default_singularity_image,
+                lines_arg=lines_with_singularity,
+                expected_singularity_image=non_default_singularity_image,
+                expected_lines=lines_without_singularity,
+            ),
+        )
+
+        for test_case in _test_cases:
+            assert (
+                test_case.expected_singularity_image
+            ), test_case.expected_lines == utils._resolve_singularity_image(
+                test_case.singularity_image_arg, test_case.lines_arg
+            )


### PR DESCRIPTION
As described in #330 , we establish the following convention here with regards to the `--singularity_image` flag and `--lines` flag with `SingularityImage` specified:

1.    If --singularity-image is specified and is NOT the default, use that.
2.   If --lines is given with a +SingularityImage classad, and that value is not the default, use that.
3.   Else, use the default.
