### PR TITLE
standardize dagnabbit errors, just print exceptions as errors 

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -230,4 +230,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -169,4 +169,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_history
+++ b/bin/jobsub_history
@@ -157,4 +157,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -345,4 +345,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/lib/dagnabbit.py
+++ b/lib/dagnabbit.py
@@ -76,7 +76,7 @@ def parse_dagnabbit(
             if line.find("<parallel>") >= 0:
                 if in_parallel:
                     sys.stderr.write(
-                        f"Error: file {values['dag']} line {linenum}: <parallel>"
+                        f"Error: file {dagfile} line {linenum}: <parallel>"
                         f" inside <parallel> not currently supported\n"
                     )
                     sys.exit(1)
@@ -167,7 +167,7 @@ def parse_dagnabbit(
                         res = parser.parse_args(line_argv)
                     except:
                         sys.stderr.write(
-                            f"Error at file {values['dag']} line {linenum}\n"
+                            f"Syntax Error at file {dagfile} line {linenum}\n"
                         )
                         sys.stderr.write(f"parsing: {line.strip().split()}\n")
                         sys.stderr.flush()
@@ -244,7 +244,7 @@ def parse_dagnabbit(
                     of.write("# saw prescript\n")
                 if in_prescript:
                     sys.stderr.write(
-                        f"Error: file {dagfile} line {linenum}\n"
+                        f"Syntax Error: file {dagfile} line {linenum}\n"
                         f" only 1 prescript line per jobsub line is allowed\n"
                     )
                     sys.exit(1)
@@ -254,7 +254,7 @@ def parse_dagnabbit(
                 try:
                     res = parser.parse_args(line.strip().split()[1:])
                 except:
-                    sys.stderr.write(f"Error at file {dagfile} line {linenum}\n")
+                    sys.stderr.write(f"Syntax Error: file {dagfile} line {linenum}\n")
                     sys.stderr.write(f"parsing: {line.strip().split()}\n")
                     sys.stderr.flush()
                     raise
@@ -271,7 +271,7 @@ def parse_dagnabbit(
                     of.write("# saw postscript\n")
                 if in_postscript:
                     sys.stderr.write(
-                        f"Error: file {dagfile} line {linenum}\n"
+                        f"Syntax Error: file {dagfile} line {linenum}\n"
                         f" only 1 postscript line per jobsub line is allowed\n"
                     )
                     sys.exit(1)
@@ -281,7 +281,7 @@ def parse_dagnabbit(
                 try:
                     res = parser.parse_args(line.strip().split()[1:])
                 except:
-                    sys.stderr.write(f"Error at file {dagfile} line {linenum}\n")
+                    sys.stderr.write(f"Syntax Error: file {dagfile} line {linenum}\n")
                     sys.stderr.write(f"parsing: {line.strip().split()}\n")
                     sys.stderr.flush()
                     raise
@@ -293,11 +293,13 @@ def parse_dagnabbit(
                 thesevalues.update(update_with)
                 set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
 
-            elif not line:
-                # blank lines are fine
+            elif not line.strip() or line.strip().startswith("#"):
+                # blank lines and comments are fine
                 pass
             else:
-                sys.stderr.write(f"Syntax Error: ignoring {line} at line {linenum}\n")
+                sys.stderr.write(
+                    f"Syntax Error: file {dagfile} ignoring {line} at line {linenum}\n"
+                )
 
         if values["maxConcurrent"]:
             of.write("CONFIG dagmax.config\n")


### PR DESCRIPTION
… without stacktraces

So before:
```
[mengel@fifeutilgpvm01 bin]$ /opt/jobsub_lite/bin/jobsub_submit -G wrong
Traceback (most recent call last):
  File "/opt/jobsub_lite/lib/fake_ifdh.py", line 221, in getProxy
    **extra_check_args,
  File "/usr/lib64/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['voms-proxy-init', '-dont-verify-ac', '-valid', '167:00', '-rfc', '-noregen', '-debug', '-cert', '/tmp/x509up_u1733', '-key', '/tmp/x509up_u1733', '-out', '/tmp/x509up_wrong_Analysis_1733', '-vomslife', '167:0', '-voms', 'fermilab:/fermilab/wrong/Role=Analysis']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/jobsub_lite/bin/jobsub_submit", line 348, in <module>
    main()
  File "/opt/jobsub_lite/bin/jobsub_submit", line 239, in main
    proxy, token = get_creds(varg)
  File "/opt/jobsub_lite/lib/creds.py", line 31, in get_creds
    p = fake_ifdh.getProxy(role, args.get("verbose", 0), args.get("force_proxy", False))
  File "/opt/jobsub_lite/lib/fake_ifdh.py", line 224, in getProxy
    raise PermissionError(f"Failed attempting '{voms_proxy_init_cmd_str}'")
PermissionError: Failed attempting 'voms-proxy-init -dont-verify-ac -valid 167:00 -rfc -noregen -debug -cert /tmp/x509up_u1733 -key /tmp/x509up_u1733 -out /tmp/x509up_wrong_Analysis_1733 -vomslife 167:0 -voms fermilab:/fermilab/wrong/Role=Analysis'
```
After
```
[mengel@fifeutilgpvm01 bin]$ ./jobsub_submit -G wrong


Error: PermissionError: Failed attempting 'voms-proxy-init -dont-verify-ac -valid 167:00 -rfc -noregen -debug -cert /tmp/x509up_u1733 -key /tmp/x509up_u1733 -out /tmp/x509up_wrong_Analysis_1733 -vomslife 167:0 -voms fermilab:/fermilab/wrong/Role=Analysis'

```