### PR TITLE
Moved huge amount of site and usage model test cases to data file

### DIFF
--- a/tests/data/singularity_image.json
+++ b/tests/data/singularity_image.json
@@ -1,0 +1,64 @@
+[
+    {
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "lines_arg": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "expected_lines": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "helptext": "--singularity_image=DEFAULT_SINGULARITY_IMAGE, --lines does not have SingularityImage:  DEFAULT_SINGULARITY_IMAGE, lines=old lines"
+    },
+    {
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "lines_arg": [
+            "key1=value1",
+            "key2=value2",
+            "+SingularityImage=\\\"/cvmfs/singularity.opensciencegrid.org/fake/image:latest_lines\\\"",
+            "key3=value3"
+        ],
+        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fake/image:latest_lines",
+        "expected_lines": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "helptext": "--singularity_image=DEFAULT_SINGULARITY_IMAGE, --lines has non-default SingularityImage:  non-default lines-Singularity_image, lines modified"
+    },
+    {
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fake/image:latest",
+        "lines_arg": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fake/image:latest",
+        "expected_lines": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "helptext": "--singularity_image=non-default-image, --lines does not have SingularityImage: non-default singularity_image from arg, lines=old lines"
+    },
+    {
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fake/image:latest",
+        "lines_arg": [
+            "key1=value1",
+            "key2=value2",
+            "+SingularityImage=\\\"/cvmfs/singularity.opensciencegrid.org/fake/image:latest_lines\\\"",
+            "key3=value3"
+        ],
+        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fake/image:latest",
+        "expected_lines": [
+            "key1=value1",
+            "key2=value2",
+            "key3=value3"
+        ],
+        "helptext": "--singularity_image=non-default-image, --lines has non-default SingularityImage: non-default singularity_image from arg, lines modified (and ignored)"
+    }
+]

--- a/tests/data/site_and_usagemodel.json
+++ b/tests/data/site_and_usagemodel.json
@@ -9,7 +9,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "no flags"
     },
     {
         "sites": "",
@@ -21,7 +22,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "onsite"
     },
     {
         "sites": "FermiGrid",
@@ -33,7 +35,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site Fermigrid"
     },
     {
         "sites": "Random_Site",
@@ -45,7 +48,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site Random_Site"
     },
     {
         "sites": "",
@@ -57,7 +61,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--offsite"
     },
     {
         "sites": "",
@@ -73,7 +78,8 @@
             "resource_provides_remainder": [
                 "usage_model=\"DEDICATED,OFFSITE\""
             ]
-        }
+        },
+        "helptext": "--resource-provides=usage_model=DEDICATED,OFFSITE"
     },
     {
         "sites": "FermiGrid",
@@ -87,7 +93,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--resource-provides=usage_model=DEDICATED,OFFSITE --site Fermigrid"
     },
     {
         "sites": "Random_Site",
@@ -101,7 +108,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--resource-provides=usage_model=DEDICATED,OFFSITE --site Random_Site"
     },
     {
         "sites": "FermiGrid,Random_Site",
@@ -115,7 +123,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site=Fermigrid,Random_Site --resource-provides=usage_model=DEDICATED,OFFSITE"
     },
     {
         "sites": "FermiGrid,Random_Site",
@@ -127,7 +136,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site=Fermigrid,Random_Site"
     },
     {
         "sites": "FermiGrid,Random_Site",
@@ -144,7 +154,8 @@
             "resource_provides_remainder": [
                 "IWANT=\"this_resource\""
             ]
-        }
+        },
+        "helptext": "--site=Fermigrid,Random_Site --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource"
     },
     {
         "sites": "",
@@ -161,7 +172,8 @@
             "resource_provides_remainder": [
                 "IWANT=\"this_resource\""
             ]
-        }
+        },
+        "helptext": "--onsite --resource_provides=usage_model=DEDICATED,OFFSITE --resource-provides=IWANT=this_resource"
     },
     {
         "sites": "",
@@ -175,7 +187,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--onsite --resource_provides=usage_model=DEDICATED,OFFSITE"
     },
     {
         "sites": "Random_Site",
@@ -189,7 +202,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--resource_provides=usage_model=DEDICATED,OPPORTUNISTIC --site Random_Site"
     },
     {
         "sites": "Random_Site",
@@ -203,7 +217,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--resource-provides=usage_model=DEDICATED --site Random_Site"
     },
     {
         "sites": "FermiGrid",
@@ -217,7 +232,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--resource-provides=usage_model=OFFSITE --site Fermigrid"
     },
     {
         "sites": "Random_Site_1,Random_Site_2",
@@ -231,7 +247,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site=Random_Site_1,Random_Site_2 --resource-provides=usage_model=DEDICATED,OFFSITE"
     },
     {
         "sites": "",
@@ -245,7 +262,8 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--onsite --resource-provides=usage_model=DEDICATED,OFFSITE"
     },
     {
         "sites": "",
@@ -259,7 +277,8 @@
                 "usage_models": "OFFSITE"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--offsite --resource-provides=usage_model=DEDICATED"
     },
     {
         "sites": "FERMIGRID",
@@ -273,6 +292,7 @@
                 "usage_models": "DEDICATED,OPPORTUNISTIC"
             },
             "resource_provides_remainder": []
-        }
+        },
+        "helptext": "--site FERMIGRID --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE (wrong case for fermigrid)"
     }
 ]

--- a/tests/data/site_and_usagemodel.json
+++ b/tests/data/site_and_usagemodel.json
@@ -1,0 +1,278 @@
+[
+    {
+        "sites": "",
+        "usage_model": "DEDICATED,OPPORTUNISTIC,OFFSITE",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "",
+                "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "DEDICATED,OPPORTUNISTIC",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FermiGrid",
+        "usage_model": "",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "Random_Site",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "OFFSITE",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "",
+                "usage_models": ""
+            },
+            "resource_provides_remainder": [
+                "usage_model=\"DEDICATED,OFFSITE\""
+            ]
+        }
+    },
+    {
+        "sites": "FermiGrid",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "Random_Site",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FermiGrid,Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid,Random_Site",
+                "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FermiGrid,Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid,Random_Site",
+                "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FermiGrid,Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\"",
+            "IWANT=\"this_resource\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid,Random_Site",
+                "usage_models": "DEDICATED,OPPORTUNISTIC,OFFSITE"
+            },
+            "resource_provides_remainder": [
+                "IWANT=\"this_resource\""
+            ]
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "DEDICATED,OPPORTUNISTIC",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\"",
+            "IWANT=\"this_resource\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": [
+                "IWANT=\"this_resource\""
+            ]
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "DEDICATED,OPPORTUNISTIC",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OPPORTUNISTIC\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "Random_Site",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "Random_Site",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "Random_Site",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FermiGrid",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "Random_Site_1,Random_Site_2",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "Random_Site_1,Random_Site_2",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "DEDICATED,OPPORTUNISTIC",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "",
+        "usage_model": "OFFSITE",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "",
+                "usage_models": "OFFSITE"
+            },
+            "resource_provides_remainder": []
+        }
+    },
+    {
+        "sites": "FERMIGRID",
+        "usage_model": "",
+        "resource_provides_quoted": [
+            "usage_model=\"DEDICATED,OPPORTUNISTIC,OFFSITE\""
+        ],
+        "expected_result": {
+            "site_and_usage_model": {
+                "sites": "FermiGrid",
+                "usage_models": "DEDICATED,OPPORTUNISTIC"
+            },
+            "resource_provides_remainder": []
+        }
+    }
+]


### PR DESCRIPTION
Table-driven tests are great, but with this trend, we will see a our test files get huge.  So I moved the test cases for the biggest offender, `test_resolve_site_and_usage_model`, to their own data file.

I did not run entire unit test suite, but I made sure that all the tests in `test_utils_unit.py` pass.