### PR TITLE
give stack traces if debug/verbose

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -49,12 +49,12 @@ class StoreGroupinEnvironment(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-arglist = argparse.Namespace()
+verbose = 0
 
 
 def main() -> None:
     """main line of code, proces args, etc."""
-    global arglist
+    global verbose
     parser = get_parser.get_jobid_parser(add_condor_epilog=True)
     parser.add_argument("-name", help="Set schedd name", default=None)
     parser.add_argument(
@@ -69,6 +69,7 @@ def main() -> None:
         parser.add_argument("--user", help="username to query", default=None)
 
     arglist, passthru = parser.parse_known_args()
+    verbose = arglist.verbose
 
     if arglist.version:
         print_version()
@@ -237,6 +238,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        if arglist.verbose:
+        if verbose:
             raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -49,8 +49,12 @@ class StoreGroupinEnvironment(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
+arglist = argparse.Namespace()
+
+
 def main() -> None:
     """main line of code, proces args, etc."""
+    global arglist
     parser = get_parser.get_jobid_parser(add_condor_epilog=True)
     parser.add_argument("-name", help="Set schedd name", default=None)
     parser.add_argument(
@@ -233,4 +237,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
+        if arglist.verbose:
+            raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -49,7 +49,7 @@ from utils import cleanup
 from version import print_version, print_support_email
 
 
-args = argparse.Namespace()
+verbose = 0
 
 
 def main():
@@ -60,7 +60,7 @@ def main():
     - condor_transfer_data
     - make tarball
     """
-    global args
+    global verbose
     parser = get_jobid_parser()
     transfer_complete = False
 
@@ -84,6 +84,8 @@ def main():
     parser.add_argument("job_id", nargs="?", help="job/submission ID")
 
     args = parser.parse_args()
+
+    verbose = args.verbose
 
     if args.version:
         print_version()
@@ -176,6 +178,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        if args.verbose:
+        if verbose:
             raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -49,6 +49,9 @@ from utils import cleanup
 from version import print_version, print_support_email
 
 
+args = argparse.Namespace()
+
+
 def main():
     """script mainline:
     - parse args
@@ -57,6 +60,7 @@ def main():
     - condor_transfer_data
     - make tarball
     """
+    global args
     parser = get_jobid_parser()
     transfer_complete = False
 
@@ -172,4 +176,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
+        if args.verbose:
+            raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_history
+++ b/bin/jobsub_history
@@ -38,12 +38,12 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 import fake_ifdh
 import get_parser
 
-arglist = argparse.Namespace()
+verbose = 0
 
 
 def main() -> None:
     """main line of code, proces args, etc."""
-    global arglist
+    global verbose
     parser = get_parser.get_jobid_parser(add_condor_epilog=True)
     parser.add_argument("--user", help="Set username to look at", default="")
     parser.add_argument(
@@ -58,6 +58,8 @@ def main() -> None:
     )
 
     arglist, passthru = parser.parse_known_args()
+
+    verbose = arglist.verbose
 
     passthru.append("-backwards")
 
@@ -163,6 +165,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        if arglist.verbose:
+        if verbose:
             raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_history
+++ b/bin/jobsub_history
@@ -38,9 +38,12 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 import fake_ifdh
 import get_parser
 
+arglist = argparse.Namespace()
+
 
 def main() -> None:
     """main line of code, proces args, etc."""
+    global arglist
     parser = get_parser.get_jobid_parser(add_condor_epilog=True)
     parser.add_argument("--user", help="Set username to look at", default="")
     parser.add_argument(
@@ -160,4 +163,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
+        if arglist.verbose:
+            raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -19,6 +19,7 @@
 
 """ submit command for jobsub layer over condor """
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
+import argparse
 import glob
 import hashlib
 import os
@@ -187,6 +188,9 @@ def transfer_sandbox(src_dir, dest_url):
             )
 
 
+args = argparse.Namespace()
+
+
 def main():
     """script mainline:
     - parse args
@@ -196,6 +200,7 @@ def main():
     - convert/render template files to submission files
     - launch
     """
+    global args
     # pylint: disable=too-many-statements
     parser = get_parser()
 
@@ -348,4 +353,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
+        if args.verbose:
+            raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -188,7 +188,7 @@ def transfer_sandbox(src_dir, dest_url):
             )
 
 
-args = argparse.Namespace()
+verbose = 0
 
 
 def main():
@@ -200,7 +200,7 @@ def main():
     - convert/render template files to submission files
     - launch
     """
-    global args
+    global verbose
     # pylint: disable=too-many-statements
     parser = get_parser()
 
@@ -209,6 +209,8 @@ def main():
     # so we do that here for backwards compatability
     backslash_escape_layer(sys.argv)
     args = parser.parse_args()
+
+    verbose = args.verbose
 
     # if they were trying to pass LD_LIBRARY_PATH to the job, get it from HIDE_LD_LIBRARY_PATH
     if "LD_LIBRARY_PATH" in args.environment and os.environ.get(
@@ -353,6 +355,6 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        if args.verbose:
+        if verbose:
             raise
         sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")


### PR DESCRIPTION
This is a second round on error cleanup; print stacktraces if verbose/debug is on.   Have to make the argument list global so we can check verbosity where we call main().