### PR TITLE
Tokens do not work on SL6 containers, so don't set BEARER_TOKEN_FILE

### DIFF
--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -18,6 +18,12 @@ do
 done
 {% endif %}
 
+if grep -q release.6 /etc/system-release
+then
+    : tokens do not work on SL6...
+    unset BEARER_TOKEN_FILE
+else
+
 {% if role is defined and role and role != 'Analysis' %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}_{{oauth_handle}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
@@ -25,6 +31,8 @@ export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{oauth_handle}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 {% endif %}
+
+fi
 
 set_jobsub_debug(){
     export PS4='$LINENO:'

--- a/tests/job_scripts/lookaround.sh
+++ b/tests/job_scripts/lookaround.sh
@@ -27,9 +27,7 @@ then
 fi
 done
 setup htgettoken
-setup ifdhc v2_6_0 -q python36, ifdhc_config v2_6_0
-export IFDH_TOKEN_ENABLE=1
-export IFDH_PROXY_ENABLE=0
+setup ifdhc
 ups active
 
 echo "============"

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -232,6 +232,15 @@ def test_dash_f_plain(dune_test_file):
 
 
 @pytest.mark.integration
+def test_dash_f_sl6(dune_test_file):
+    lookaround_launch(
+        f"-f {dune_test_file} "
+        "--singularity=/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl6:latest",
+        f"\\$CONDOR_DIR_INPUT/{os.path.basename(dune_test_file)}",
+    )
+
+
+@pytest.mark.integration
 def test_dash_f_dropbox_cvmfs(dune):
     lookaround_launch(
         f"-f dropbox://{__file__} --use-cvmfs-dropbox",


### PR DESCRIPTION

Several groups using SL6 containers have been running into roadblocks using jobsub_lite;
the main underlying issue is that there is no token support to be had in the underlying
gfal-utilities, etc. on SL6.  

