### PR TITLE
Update invalid constraint tests so they do not use default jobsub_q output format

### DIFF
--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -493,7 +493,7 @@ def test_valid_constraint_equal(samdev):
 
 @pytest.mark.integration
 def test_invalid_constraint_space(samdev):
-    cmd = f"jobsub_q -G fermilab --constraint 'thisisabadconstraintbutwillparse==true'"
+    cmd = f"jobsub_q -G fermilab --constraint 'thisisabadconstraintbutwillparse==true' -autoformat ClusterId"
     query = os.popen(cmd)
     output = query.readlines()
     assert len(output) == 0
@@ -505,7 +505,7 @@ def test_invalid_constraint_space(samdev):
 
 @pytest.mark.integration
 def test_invalid_constraint_equal(samdev):
-    cmd = f"jobsub_q -G fermilab --constraint='thisisabadconstraintbutwillparse==true'"
+    cmd = f"jobsub_q -G fermilab --constraint='thisisabadconstraintbutwillparse==true' -autoformat ClusterId"
     query = os.popen(cmd)
     output = query.readlines()
     assert len(output) == 0


### PR DESCRIPTION
In testing the 1.2 release, two integration tests failed because they ran `jobsub_q`, which now prints out the default header, whether or not a job matching the constraint was found.  This broke both tests, because they check the length of the returned output to make sure it's zero.  This change was simply to force jobsub_q to pull down just the job information, since we're testing invalid constraints, and thus there should be no jobs to report on.