### PR TITLE
Tests cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 import pytest
@@ -20,7 +21,7 @@ import creds
 
 
 @pytest.fixture
-def needs_credentials():
+def needs_credentials(check_user_kerberos_creds):
     os.environ["GROUP"] = TestUnit.test_group
     return creds.get_creds({"role": "Analysis"})
 
@@ -33,3 +34,15 @@ def clear_x509_user_proxy():
 
     if old_x509_user_proxy_value is not None:
         os.environ["X509_USER_PROXY"] = old_x509_user_proxy_value
+
+
+@pytest.fixture
+def check_user_kerberos_creds():
+    """Make sure we have kerberos credentials before starting the test"""
+    proc = subprocess.run(
+        ["klist"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="UTF-8"
+    )
+    if proc.returncode or ("No credentials cache found" in proc.stdout):
+        raise Exception(
+            f"No kerberos credentials found.  Please run kinit and try again.  Error: {proc.stdout}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+import pytest
+
+#
+# we assume everwhere our current directory is in the package
+# test area, so go ahead and cd there
+#
+os.chdir(os.path.dirname(__file__))
+
+from test_unit import TestUnit
+
+#
+# import modules we need to test, since we chdir()ed, can use relative path
+#
+sys.path.append("../lib")
+
+import creds
+
+
+@pytest.fixture
+def needs_credentials():
+    os.environ["GROUP"] = TestUnit.test_group
+    return creds.get_creds({"role": "Analysis"})
+
+
+@pytest.fixture
+def clear_x509_user_proxy():
+    """Clear environment variable X509_USER_PROXY to test credentials overrides"""
+    old_x509_user_proxy_value = os.environ.pop("X509_USER_PROXY", None)
+    yield
+
+    if old_x509_user_proxy_value is not None:
+        os.environ["X509_USER_PROXY"] = old_x509_user_proxy_value

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -21,7 +21,6 @@ else:
 import condor
 
 from test_unit import TestUnit
-from test_creds_unit import needs_credentials
 
 
 @pytest.fixture

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -21,22 +21,6 @@ import creds
 from test_unit import TestUnit
 
 
-@pytest.fixture
-def needs_credentials():
-    os.environ["GROUP"] = TestUnit.test_group
-    return creds.get_creds({"role": "Analysis"})
-
-
-@pytest.fixture
-def clear_x509_user_proxy():
-    """Clear environment variable X509_USER_PROXY to test credentials overrides"""
-    old_x509_user_proxy_value = os.environ.pop("X509_USER_PROXY", None)
-    yield
-
-    if old_x509_user_proxy_value is not None:
-        os.environ["X509_USER_PROXY"] = old_x509_user_proxy_value
-
-
 class TestCredUnit:
     """
     Use with pytest... unit tests for ../lib/*.py

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -25,7 +25,6 @@ import tarfiles
 import get_parser
 
 from test_unit import TestUnit
-from test_creds_unit import needs_credentials
 
 
 class TestTarfilesUnit:

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -25,8 +25,6 @@ else:
 import utils
 
 from test_unit import TestUnit
-from test_creds_unit import needs_credentials  # pylint: disable=unused-import
-from test_creds_unit import clear_x509_user_proxy  # pylint: disable=unused-import
 
 DATADIR = f"{os.path.abspath(os.path.dirname(__file__))}/data"
 


### PR DESCRIPTION
This PR simply starts to clean up some of our unit tests by doing the following:

1.  Move shared test fixtures into `conftest.py`, which is the [recommended pytest way](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files) of sharing fixtures across multiple test files
2.  Use the fixtures we have like `clear_x509_user_proxy` in older tests where we might have neglected to use the fixture, and are thus duplicating test code.
3. Formally parametrize some of the tests where we run the same test on multiple cases to take advantage of pytests's parametrization functionality (i.e. dynamically generating multiple named tests from a single test so all of the cases run, and we can clearly see which case failed).

Note:  I kept this in draft status so that we don't accidentally merge it before 1.2 is deployed on April 6, 2023; in case we need to make an emergency patch or something like that.