### PR TITLE
closes #281, closes #237

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -192,6 +192,11 @@ def transfer_sandbox(src_dir, dest_url):
 verbose = 0
 
 
+def get_env_list(name: str) -> List[str]:
+    """get a split comma separated list of strings from an environment variable"""
+    return [x for x in os.environ.get(name, "").split(",") if x]
+
+
 def main():
     """script mainline:
     - parse args
@@ -210,6 +215,13 @@ def main():
     # so we do that here for backwards compatability
     backslash_escape_layer(sys.argv)
     args = parser.parse_args()
+
+    # Allow environment variables to append to some command lists to get rid of
+    # need for poms_jobsub_wrapper to get in front of us on the path -- we will
+    # just set these and have a job-info script report the job id, etc.
+    args.environment.extend(get_env_list("JOBSUB_EXTRA_ENVIRONMENT"))
+    args.lines.extend(get_env_list("JOBSUB_EXTRA_LINES"))
+    args.job_info.extend(get_env_list("JOBSUB_EXTRA_JOB_INFO"))
 
     verbose = args.verbose
 

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -179,6 +179,12 @@ def submit(
         if m:
             print(f"{hl}Use job id {m.group(1)}.0@{schedd_name} to retrieve output{hl}")
 
+            # call any job_info commands requested with the jobid
+            for ji in vargs["job_info"]:
+                os.system(
+                    f'{ji} {m.group(1)}.0@{schedd_name} "{repr(sys.argv)}" </dev/null'
+                )
+
         return True
     except OSError as e:
         print("Execution failed: ", e)

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -281,6 +281,12 @@ def get_parser() -> argparse.ArgumentParser:
         " jobs in a DAG",
     )
     parser.add_argument(
+        "--job-info",
+        action="append",
+        default=[],
+        help="script to call with jobid, etc. when job is launched",
+    )
+    parser.add_argument(
         "-L", "--log-file", "--log_file", help="Log file to hold log output from job."
     )
     parser.add_argument(


### PR DESCRIPTION
adds `--job-info scriptname` option and JOBSUB_EXTRA_JOB_INFO, JOBSUB_EXTRA_LINES, JOBSUB_EXTRA_ENVIRONMENT environment variables to augment the command line argument lists --job-info, --environment , and --lines,

So now you can `export  JOBSUB_EXTRA_ENVIRONMENT=IFDH_DEBUG=1` and all your submissions will get ifdh debugging turned on, without changing your scripts.

But it's really to get rid of the ugliness that is poms_jobsub_wrapper...