### PR TITLE
Fixed unit tests vargs to work with new generate-email-summary flag

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -37,6 +37,7 @@ class TestUnit:
         "oauth_handle": "0a1b2c3d4e5f",
         "project_name": "",
         "job_info": [],
+        "generate_email_summary": False,
     }
     test_extra_template_args = {
         "role": "Analysis",


### PR DESCRIPTION
In preparing 1.2.1, I found that one unit test failed because we had failed to update test_unit vargs.  With this PR, all unit tests pass.