### PR TITLE
Cleanup integration tests

### DIFF
--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -22,6 +22,20 @@ import get_parser
 import pool
 
 from test_unit import TestUnit
+from test_submit_wait_int import get_collector
+
+
+def set_pool_map():
+    """we need a pool map set to test the --global-pool option"""
+    os.environ["GROUP"] = "dune"
+    os.environ["JOBSUB_POOL_MAP"] = (
+        '{"dune":{"collector":"' + get_collector() + '","onsite":"FNAL_GPGRID"}}'
+    )
+    del os.environ["GROUP"]
+
+
+# we need to set the pool map when we're imported...
+set_pool_map()
 
 
 @pytest.fixture

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -135,6 +135,8 @@ def dune_gp(dune):
 joblist = []
 jid2test = {}
 jid2nout = {}
+jid2group = {}
+jid2pool = {}
 outdirs = {}
 ddirs = {}
 
@@ -149,6 +151,8 @@ def run_launch(cmd, expected_out=1):
     outdir = None
     jobsubjobid = None
     added = False
+    # do not submit too fast...
+    time.sleep(1)
     pf = os.popen(cmd + " 2>&1")
     for l in pf.readlines():
         print(l)
@@ -169,10 +173,14 @@ def run_launch(cmd, expected_out=1):
         if jobid and schedd and jobsubjobid and not added:
             added = True
             print("Found all three! ", jobid, schedd, jobsubjobid)
-            joblist.append("%s@%s" % (jobid, schedd))
+            joblist.append("%s.0@%s" % (jobid, schedd))
             # note which test led to this jobid
-            jid2test["%s@%s" % (jobid, schedd)] = inspect.stack()[2][3]
-            jid2nout["%s@%s" % (jobid, schedd)] = expected_out
+            jid2test["%s.0@%s" % (jobid, schedd)] = inspect.stack()[2][3]
+            jid2nout["%s.0@%s" % (jobid, schedd)] = expected_out
+            jid2group["%s.0@%s" % (jobid, schedd)] = os.environ.get("GROUP", "fermilab")
+            jid2pool["%s.0@%s" % (jobid, schedd)] = os.environ.get(
+                "_condor_COLLECTOR_HOST", ""
+            )
     res = pf.close()
 
     if not added:
@@ -190,7 +198,7 @@ def run_launch(cmd, expected_out=1):
 def lookaround_launch(extra, verify_files=""):
     """Simple submit of our lookaround script"""
     assert run_launch(
-        f"jobsub_submit --verbose=1 -e SAM_EXPERIMENT {extra} file://`pwd`/job_scripts/lookaround.sh {verify_files}"
+        f"jobsub_submit --mail-never --verbose=1 -e SAM_EXPERIMENT {extra} file://`pwd`/job_scripts/lookaround.sh {verify_files}"
     )
 
 
@@ -288,6 +296,7 @@ def dagnabbit_launch(extra, which="", nout_files=5):
     res = run_launch(
         f"""
         jobsub_submit \
+          --mail-never \
           --verbose=2 \
           -e SAM_EXPERIMENT {extra} \
           --dag file://dagTest{which} \
@@ -325,6 +334,7 @@ def fife_launch(extra):
     assert run_launch(
         """
         jobsub_submit \
+          --mail-never \
           --verbose=1 \
           -e EXPERIMENT \
           -e IFDH_DEBUG \
@@ -372,7 +382,8 @@ def fife_launch(extra):
               gen.troot \
               -c \
               hist_gen.troot """
-        % {"exp": os.environ["GROUP"], "extra": extra}
+        % {"exp": os.environ["GROUP"], "extra": extra},
+        expected_out=5,
     )
 
 
@@ -397,19 +408,27 @@ def test_dune_gp_fife_launch(dune_gp):
 
 
 def group_for_job(jid):
+
+    group = jid2group.get(jid, "")
+
     if jid.find("dune") > 0:
-        group = "dune"
-        os.environ["GROUP"] = group
-        os.environ["_condor_COLLECTOR_HOST"] = get_collector()
+        if not group:
+            group = "dune"
+        if jid2pool.get(jid, ""):
+            os.environ["_condor_COLLECTOR_HOST"] = get_collector()
     else:
-        group = "fermilab"
+        if not group:
+            group = "fermilab"
         if os.environ.get("_condor_COLLECTOR_HOST"):
             del os.environ["_condor_COLLECTOR_HOST"]
+    os.environ["GROUP"] = group
     return group
 
 
-@pytest.mark.integration
-def test_jobsub_q_repetitions(samdev):
+# turning this test off for now; I can not seem to get it to consistently get
+# the setup of two jobs each on two schedd's... mengel
+# @pytest.mark.integration
+def xx_test_jobsub_q_repetitions(samdev):
     # test to make sure if we do jobsub_q 1@jobsub01 2@jobsub01 3@jobsub02 4@jobsub02 we get only one repitition
     # first submit a few more jobs so we have fresh ones
     lookaround_launch("")
@@ -436,7 +455,7 @@ def test_jobsub_q_repetitions(samdev):
     for schedd in all_schedds_l:
         # pick the most recent 2 of jobs from each schedd
         nj = len(jobs_by_schedd[schedd])
-        if nj > 1:
+        if nj > 1 and not schedd.find("dune") == 0:
             args.append(jobs_by_schedd[schedd][-1])
             args.append(jobs_by_schedd[schedd][-2])
             jcount = jcount + 2
@@ -465,8 +484,10 @@ def test_wait_for_jobs():
     with open("/tmp/jobsub_lite_test_joblist", "w") as f:
         f.write(" ".join(joblist))
 
-    while count > 0:
-        time.sleep(10)
+    repeats = 0
+    while count > 0 and repeats < 3:
+        if repeats == 0:
+            time.sleep(20)
         count = len(joblist)
         for jid in joblist:
             group = group_for_job(jid)
@@ -487,6 +508,13 @@ def test_wait_for_jobs():
                 #     all completed...)
                 # None is when there's no output...
                 count = count - 1
+
+        # have to all look good 3 times in a row...
+        if count == 0:
+            repeats = repeats + 1
+        else:
+            repeats = 0
+
     print("Done.")
     assert True
 
@@ -514,12 +542,34 @@ def test_check_job_output():
     for jid, outdir in outdirs.items():
         fl = glob.glob("%s/*[0-9].out" % outdir)
 
+        if len(fl) < jid2nout[jid]:
+            # if not enough files, try fetching again...
+            # sometimes when we look later they're all there
+            print(f"Notice: re-fetching {jid} logs...")
+            group = group_for_job(jid)
+            subprocess.run(
+                [
+                    "jobsub_fetchlog",
+                    "--group",
+                    group,
+                    "--jobid",
+                    jid,
+                    "--destdir",
+                    outdir,
+                ],
+                check=True,
+            )
+            fl = glob.glob("%s/*[0-9].out" % outdir)
+
         # make sure we have enough output files
+        print(
+            f"Checking out file count test {jid2test[jid]} {jid} expecting {jid2nout[jid]} actual count {len(fl)}"
+        )
         if len(fl) >= jid2nout[jid]:
-            print(f"-- ok: {len(fl)} files for {jid} --  expected {jid2nout[jid]}")
+            print("-- ok")
         else:
             res = False
-            print(f"-- bad: {len(fl)} files for {jid} --  expected {jid2nout[jid]}")
+            print("-- bad")
 
         for f in fl:
             print(f"Checking {jid2test[jid]} {jid} output file {f}...")


### PR DESCRIPTION
Working harder to use the right group / collector to fetch logs.

Dropping the test for repeating schedd's in jobsub_cmd,  as the setup to try to get 2 jobs on 2 schedd's  just doesn't seem to be reliable.

