### PR TITLE
Dropbox selector as cycle

### DIFF
--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -285,14 +285,18 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
         # cid looks something like dune/bf6a15b4238b72f82...(long hash)
         cid = f"{args.group}/{digest}"
 
-        publisher = TarfilePublisherHandler(cid, proxy, token)
+        publisher = TarfilePublisherHandler(cid, proxy, token, args.verbose)
         location = publisher.cid_exists()
         if location is None:
             if args.verbose:
                 print(f"\n\nUsing RCDS to publish tarball\ncid: {cid}")
             publisher.publish(tf)
             if not getattr(args, "skip_check_rcds", False):
-                print("Checking to see if uploaded file is published on RCDS.")
+                msg = "Checking to see if uploaded file is published on RCDS"
+                if args.verbose:
+                    msg = msg + f" for CID {cid}"
+                print(msg)
+
                 # pylint: disable-next=unused-variable
                 for i in range(NUM_RETRIES):
                     location = publisher.cid_exists()
@@ -363,12 +367,18 @@ class TarfilePublisherHandler:
     )  # RCDS returns this if a tarball represented by cid is present
 
     def __init__(
-        self, cid: str, proxy: Union[None, str] = None, token: Union[None, str] = None
+        self,
+        cid: str,
+        proxy: Union[None, str] = None,
+        token: Union[None, str] = None,
+        verbose: int = 0,
     ):
         self.cid = cid
         self.cid_url = _quote(cid, safe="")  # Encode CID for passing to URL
         self.proxy = proxy
         self.token = token
+        self.verbose = verbose
+
         if token is not None:
             print(f"Using bearer token located at {self.token} to authenticate to RCDS")
         else:
@@ -403,6 +413,8 @@ class TarfilePublisherHandler:
             while True:
                 try:
                     _dropbox_server = next(_dropbox_server_selector)
+                    if self.verbose > 0:
+                        print(f"Using PubAPI server {_dropbox_server}")
                     self.pubapi_base_url_formatter = (
                         self.pubapi_base_url_formatter_full.format_map(
                             SafeDict(dropbox_server=_dropbox_server)
@@ -415,6 +427,8 @@ class TarfilePublisherHandler:
                     response = func(self, *args, **kwargs)
                     response.raise_for_status()
                 except:  # pylint: disable=bare-except
+                    # Note:  This retry loop is in case the request itself fails.  Not
+                    # if we couldn't find the tarball!
                     tb.print_exc()
                     if next(retry_count) == NUM_RETRIES:
                         print(f"Max retries {NUM_RETRIES} exceeded.  Exiting now.")
@@ -444,14 +458,16 @@ class TarfilePublisherHandler:
     @cid_operation
     @pubapi_operation
     def update_cid(self) -> requests.Response:
-        """Make PubAPI update call to check if we
-        already have this tarfile
+        """Make PubAPI update call to update the last-accessed timestamp on
+        this tarfile
 
         Returns:
             requests.Response: Response from PubAPI call indicating if tarball
             represented by self.cid is present
         """
         url = self.pubapi_cid_url_formatter.format(endpoint="update")
+        if self.verbose:
+            print(f"Calling URL {url}")
         if self.token:
             return requests.get(url, auth=TokenAuth(self.token))
         return requests.get(url, cert=(self.proxy, self.proxy))
@@ -469,6 +485,8 @@ class TarfilePublisherHandler:
             represented by self.cid is present
         """
         url = self.pubapi_cid_url_formatter.format(endpoint="publish")
+        if self.verbose:
+            print(f"Calling URL {url}")
         if self.token:
             return requests.post(url, auth=TokenAuth(self.token), data=tarfile)
         return requests.post(url, cert=(self.proxy, self.proxy), data=tarfile)
@@ -483,6 +501,8 @@ class TarfilePublisherHandler:
             represented by self.cid is present
         """
         url = self.pubapi_cid_url_formatter.format(endpoint="exists")
+        if self.verbose:
+            print(f"Calling URL {url}")
         if self.token:
             return requests.get(url, auth=TokenAuth(self.token))
         return requests.get(url, cert=(self.proxy, self.proxy))


### PR DESCRIPTION
Realized that a custom-made generator in the `TarfilePublisherHandler` does the same thing as `itertools.cycle`, so replaced that.  Also contains a bugfix where we used to reset the above-mentioned generator every API call rather than with every new CID.  So you could get something like:

```
for cid fermilab/12345

use dropbox_server_1 (fail)
use dropbox_server_2 (fail) 
use dropbox_server_2 (fail)
use dropbox_server_2 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (fail)
use dropbox_server_2 (pass)
```

Rather than the intended:

```
for cid fermilab/12345

use dropbox_server_1 (fail)
use dropbox_server_2 (fail) 
use dropbox_server_2 (fail)
use dropbox_server_1 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (fail)
use dropbox_server_1 (fail)
use dropbox_server_2 (pass)
```

With this fix, I redesigned it a little bit, so that we might get:

```
for cid fermilab/12345

use dropbox_server_1 (fail)
use dropbox_server_2 (fail) 
use dropbox_server_1 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (pass)
```

But for the next cid in the same submission, we might see

```
for cid fermilab/67890

use dropbox_server_2 (fail) 
use dropbox_server_1 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (fail)
use dropbox_server_2 (fail)
use dropbox_server_1 (pass)
```

This is a slight redesign, in that we don't shuffle every time we go through the cycle, but that's OK, since the intent is to ensure that we try each dropbox server once in each retry cycle.