### PR TITLE
deal with extra slashes in, i.e. , dropbox:////some/place #396

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -234,6 +234,10 @@ gfal_clean_env = (
 
 
 def fix_pnfs(path: str) -> str:
+
+    if path[0] == "/":
+        path = os.path.realpath(path)
+
     # use nfs4 mount if present
     mountpoint_end = path.find("/", 7)
     if os.path.isdir(path[:mountpoint_end]):

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -304,6 +304,14 @@ def test_dash_f_dropbox_pnfs(dune):
     )
 
 
+@pytest.mark.integration
+def test_dash_f_dropbox_pnfs_exra_slashes(dune):
+    lookaround_launch(
+        f"-f dropbox:////{__file__} --use-pnfs-dropbox",
+        f"\\$CONDOR_DIR_INPUT/{os.path.basename(__file__)}",
+    )
+
+
 def dagnabbit_launch(extra, which="", nout_files=5):
     os.environ["SUBMIT_FLAGS"] = ""
     os.chdir(os.path.join(os.path.dirname(__file__), "dagnabbit"))


### PR DESCRIPTION
Small tweak in fake_ifdh.py to keep it from getting confused by extra slashes, or passing them on to gfal-copy and confusing it.   Does not mess with other URL types, etc.